### PR TITLE
Systemd service, Makefile and README-updates on the usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,148 @@
+.PHONY: help install install-dev install-all test lint format clean uninstall install-service uninstall-service enable-service disable-service setup-wayland
+
+help:
+	@echo "Available targets:"
+	@echo "  install-all       - Complete setup (install + enable service)"
+	@echo "  install           - Install the package using pipx"
+	@echo "  install-dev       - Install with development dependencies"
+	@echo "  test              - Run tests"
+	@echo "  lint              - Run linting (ruff check)"
+	@echo "  format            - Format code (ruff format)"
+	@echo "  clean             - Remove build artifacts and cache"
+	@echo "  install-service   - Install systemd user service"
+	@echo "  uninstall-service - Uninstall systemd user service"
+	@echo "  enable-service    - Install and enable the service"
+	@echo "  disable-service   - Disable and stop the service"
+	@echo "  setup-wayland     - Configure Wayland environment import"
+	@echo "  uninstall         - Uninstall the package"
+	@echo "WARNING: This large amount of targets was made by an eager AI-bot"
+	@echo "Only enable-service and setup-wayland has been tested, the latter with sway"
+
+install:
+	pipx install .
+	@echo ""
+	@echo "✓ aw-watcher-ask-away installed successfully!"
+	@echo ""
+	@echo "Next steps:"
+	@echo "  1. Recommended: Use aw-qt (ActivityWatch GUI)"
+	@echo "     aw-qt will detect and start this watcher automatically"
+	@echo ""
+	@echo "  2. Alternative: Run as systemd service"
+	@echo "     make enable-service"
+	@echo ""
+	@echo "  3. For Wayland users running systemd:"
+	@echo "     make setup-wayland"
+	@echo ""
+	@echo "  4. Test manually:"
+	@echo "     aw-watcher-ask-away"
+	@echo ""
+
+install-dev:
+	pip install -e ".[dev]"
+
+install-all: install enable-service
+	@echo ""
+	@echo "✓ Installation complete!"
+	@echo "  The watcher is now installed and running as a systemd service."
+	@echo ""
+	@echo "Check status with: systemctl --user status aw-watcher-ask-away"
+	@echo "View logs with:    journalctl --user -u aw-watcher-ask-away -f"
+	@echo ""
+	@echo "Note: Wayland users should also run: make setup-wayland"
+
+test:
+	pytest tests/ -v
+
+lint:
+	ruff check .
+
+format:
+	ruff format .
+
+clean:
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".ruff_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name "*.pyc" -delete
+	rm -rf dist/ build/
+
+install-service:
+	@echo "Installing systemd user service..."
+	mkdir -p ~/.config/systemd/user
+	cp misc/aw-watcher-ask-away.service ~/.config/systemd/user/
+	systemctl --user daemon-reload
+	@echo "Service installed. Use 'make enable-service' to enable and start it."
+
+uninstall-service:
+	@echo "Uninstalling systemd user service..."
+	systemctl --user stop aw-watcher-ask-away 2>/dev/null || true
+	systemctl --user disable aw-watcher-ask-away 2>/dev/null || true
+	rm -f ~/.config/systemd/user/aw-watcher-ask-away.service
+	systemctl --user daemon-reload
+	@echo "Service uninstalled."
+
+enable-service: install-service
+	@echo "Enabling and starting service..."
+	systemctl --user enable aw-watcher-ask-away
+	systemctl --user start aw-watcher-ask-away
+	@echo "Service status:"
+	@systemctl --user status aw-watcher-ask-away --no-pager
+
+disable-service:
+	@echo "Disabling and stopping service..."
+	systemctl --user stop aw-watcher-ask-away
+	systemctl --user disable aw-watcher-ask-away
+	@echo "Service disabled."
+
+setup-wayland: enable-service
+	@echo "Configuring Wayland environment import..."
+	@echo ""
+	@echo "Detecting compositor configuration files..."
+	@if [ -f ~/.config/sway/config ]; then \
+		echo "Found Sway config at ~/.config/sway/config"; \
+		if grep -q "systemctl --user import-environment WAYLAND_DISPLAY" ~/.config/sway/config; then \
+			echo "✓ Environment import already configured"; \
+		else \
+			echo "" >> ~/.config/sway/config; \
+			echo "# Import WAYLAND_DISPLAY for systemd services" >> ~/.config/sway/config; \
+			echo "exec systemctl --user import-environment WAYLAND_DISPLAY" >> ~/.config/sway/config; \
+			echo "✓ Added environment import to Sway config"; \
+			echo "  Please reload Sway config or log out and back in"; \
+		fi; \
+	elif [ -f ~/.config/hypr/hyprland.conf ]; then \
+		echo "Found Hyprland config at ~/.config/hypr/hyprland.conf"; \
+		if grep -q "systemctl --user import-environment WAYLAND_DISPLAY" ~/.config/hypr/hyprland.conf; then \
+			echo "✓ Environment import already configured"; \
+		else \
+			echo "" >> ~/.config/hypr/hyprland.conf; \
+			echo "# Import WAYLAND_DISPLAY for systemd services" >> ~/.config/hypr/hyprland.conf; \
+			echo "exec-once = systemctl --user import-environment WAYLAND_DISPLAY" >> ~/.config/hypr/hyprland.conf; \
+			echo "✓ Added environment import to Hyprland config"; \
+			echo "  Please reload Hyprland config or log out and back in"; \
+		fi; \
+	else \
+		echo "Could not detect compositor config file."; \
+		echo ""; \
+		echo "Please manually add this line to your compositor startup:"; \
+		echo "  exec systemctl --user import-environment WAYLAND_DISPLAY"; \
+		echo ""; \
+		echo "Common locations:"; \
+		echo "  - Sway: ~/.config/sway/config"; \
+		echo "  - Hyprland: ~/.config/hypr/hyprland.conf"; \
+		echo "  - Others: check your compositor documentation"; \
+	fi
+	@echo ""
+	@echo "Restarting service to pick up environment changes..."
+	@systemctl --user restart aw-watcher-ask-away 2>/dev/null || echo "Note: Service restart will happen after compositor reload"
+	@echo ""
+	@echo "⚠ IMPORTANT: The environment variable will only be available after:"
+	@echo "  1. Reloading your compositor config, OR"
+	@echo "  2. Logging out and back in"
+	@echo ""
+	@echo "After that, verify the service is working:"
+	@echo "  systemctl --user status aw-watcher-ask-away"
+
+uninstall:
+	pipx uninstall aw-watcher-ask-away 2>/dev/null || true
+	@echo "Package uninstalled."

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,20 @@ help:
 	@echo "Only enable-service and setup-wayland has been tested, the latter with sway"
 
 install:
+	@command -v pipx >/dev/null 2>&1 || { \
+		echo "Error: pipx is not installed"; \
+		echo ""; \
+		echo "Please install pipx first:"; \
+		echo "  https://pypa.github.io/pipx/installation/"; \
+		echo ""; \
+		echo "Quick install options:"; \
+		echo "  - Arch Linux: sudo pacman -S python-pipx"; \
+		echo "  - Debian/Ubuntu: sudo apt install pipx"; \
+		echo "  - Fedora: sudo dnf install pipx"; \
+		echo "  - macOS: brew install pipx"; \
+		echo "  - pip: python3 -m pip install --user pipx"; \
+		exit 1; \
+	}
 	pipx install .
 	@echo ""
 	@echo "✓ aw-watcher-ask-away installed successfully!"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,50 @@ pipx install aw-watcher-ask-away
 
 ([Need to install `pipx` first?](https://pypa.github.io/pipx/installation/))
 
+## Running
+
+### Recommended: Using aw-qt
+
+The recommended way to run this watcher is through [aw-qt](https://github.com/ActivityWatch/aw-qt), which manages both the server and watchers automatically. After installing aw-watcher-ask-away, aw-qt should detect and start it automatically.
+
+### Alternative: Manual Start
+
+If not using aw-qt, you can run it manually:
+```console
+aw-watcher-ask-away
+```
+
+Make sure `aw-server` and `aw-watcher-afk` are running first, as this watcher monitors AFK events.
+
+### Alternative: systemd (Linux)
+
+For users not using aw-qt who want automatic startup via systemd:
+
+**Quick setup with Makefile:**
+```console
+make enable-service
+```
+
+**For Wayland users, also run:**
+```console
+make setup-wayland
+```
+
+This automatically configures your compositor to import the WAYLAND_DISPLAY environment variable.
+
+**Manual setup (if preferred):**
+```console
+cp misc/aw-watcher-ask-away.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable aw-watcher-ask-away.service
+systemctl --user start aw-watcher-ask-away.service
+```
+
+For Wayland, manually add to your compositor config:
+```
+exec systemctl --user import-environment WAYLAND_DISPLAY
+```
+
 ## Roadmap
 
 Most of the improvements involve a more complicated pop-up window.

--- a/misc/aw-watcher-ask-away.service
+++ b/misc/aw-watcher-ask-away.service
@@ -1,0 +1,50 @@
+########################################
+# aw-watcher-ask-away.service         #
+########################################
+#
+# This service file provides an alternative way to run aw-watcher-ask-away
+# without using aw-qt. The recommended approach is to use aw-qt, which manages
+# both the server and watchers automatically.
+#
+# This watcher shows GUI dialogs when you return from AFK, so it needs access
+# to your display server.
+#
+# Prerequisites:
+# - aw-server must be installed and running
+# - aw-watcher-afk must be running (ask-away monitors AFK events)
+# - This watcher must be installed (pip install aw-watcher-ask-away)
+#
+# Installation for X11 users:
+# 1. Copy service file: cp misc/aw-watcher-ask-away.service ~/.config/systemd/user/
+# 2. Reload systemd: systemctl --user daemon-reload
+# 3. Enable the service: systemctl --user enable aw-watcher-ask-away.service
+# 4. Start the service: systemctl --user start aw-watcher-ask-away.service
+#
+# Additional setup for Wayland users:
+# - Add to your compositor startup script (e.g., ~/.config/sway/config):
+#   exec systemctl --user import-environment WAYLAND_DISPLAY
+# - This ensures the service can access your Wayland display
+#
+# The watcher will automatically retry connection to aw-server if it's not ready yet.
+#
+
+[Unit]
+Description=ActivityWatch AFK Questionnaire Watcher
+Documentation=https://github.com/Jeremiah-England/aw-watcher-ask-away
+After=aw-server.service
+# Ensure we run within a graphical session
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=aw-watcher-ask-away
+Restart=on-failure
+RestartSec=10
+Environment=PYTHONUNBUFFERED=1
+# Set DISPLAY for X11 users (Wayland users should import WAYLAND_DISPLAY)
+Environment="DISPLAY=:0"
+# Note: For Wayland, also run: systemctl --user import-environment WAYLAND_DISPLAY
+# Add this command to your compositor/session startup script
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Add comprehensive documentation for different ways to run the watcher:
- Recommended: via aw-qt (automatic)
- Alternative: manual start
- Alternative: systemd service for Linux users

Include systemd service file with support for both X11 and Wayland.

Add Makefile with convenient targets:
- make enable-service: Install and start systemd service
- make setup-wayland: Auto-configure Wayland environment import
  (detects Sway/Hyprland and adds import-environment command)

Simplifies setup for users.

DISCLAIMER: Most of this pull request was AI-generated.  The Make-target setup-wayland was tested with Sway, and the service seems to work from user-level systemd for me.
