### PR TITLE
feat: Add config file support and lid watcher integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,148 @@
+.PHONY: help install install-dev install-all test lint format clean uninstall install-service uninstall-service enable-service disable-service setup-wayland
+
+help:
+	@echo "Available targets:"
+	@echo "  install-all       - Complete setup (install + enable service)"
+	@echo "  install           - Install the package using pipx"
+	@echo "  install-dev       - Install with development dependencies"
+	@echo "  test              - Run tests"
+	@echo "  lint              - Run linting (ruff check)"
+	@echo "  format            - Format code (ruff format)"
+	@echo "  clean             - Remove build artifacts and cache"
+	@echo "  install-service   - Install systemd user service"
+	@echo "  uninstall-service - Uninstall systemd user service"
+	@echo "  enable-service    - Install and enable the service"
+	@echo "  disable-service   - Disable and stop the service"
+	@echo "  setup-wayland     - Configure Wayland environment import"
+	@echo "  uninstall         - Uninstall the package"
+	@echo "WARNING: This large amount of targets was made by an eager AI-bot"
+	@echo "Only enable-service and setup-wayland has been tested, the latter with sway"
+
+install:
+	pipx install .
+	@echo ""
+	@echo "✓ aw-watcher-ask-away installed successfully!"
+	@echo ""
+	@echo "Next steps:"
+	@echo "  1. Recommended: Use aw-qt (ActivityWatch GUI)"
+	@echo "     aw-qt will detect and start this watcher automatically"
+	@echo ""
+	@echo "  2. Alternative: Run as systemd service"
+	@echo "     make enable-service"
+	@echo ""
+	@echo "  3. For Wayland users running systemd:"
+	@echo "     make setup-wayland"
+	@echo ""
+	@echo "  4. Test manually:"
+	@echo "     aw-watcher-ask-away"
+	@echo ""
+
+install-dev:
+	pip install -e ".[dev]"
+
+install-all: install enable-service
+	@echo ""
+	@echo "✓ Installation complete!"
+	@echo "  The watcher is now installed and running as a systemd service."
+	@echo ""
+	@echo "Check status with: systemctl --user status aw-watcher-ask-away"
+	@echo "View logs with:    journalctl --user -u aw-watcher-ask-away -f"
+	@echo ""
+	@echo "Note: Wayland users should also run: make setup-wayland"
+
+test:
+	pytest tests/ -v
+
+lint:
+	ruff check .
+
+format:
+	ruff format .
+
+clean:
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".ruff_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name "*.pyc" -delete
+	rm -rf dist/ build/
+
+install-service:
+	@echo "Installing systemd user service..."
+	mkdir -p ~/.config/systemd/user
+	cp misc/aw-watcher-ask-away.service ~/.config/systemd/user/
+	systemctl --user daemon-reload
+	@echo "Service installed. Use 'make enable-service' to enable and start it."
+
+uninstall-service:
+	@echo "Uninstalling systemd user service..."
+	systemctl --user stop aw-watcher-ask-away 2>/dev/null || true
+	systemctl --user disable aw-watcher-ask-away 2>/dev/null || true
+	rm -f ~/.config/systemd/user/aw-watcher-ask-away.service
+	systemctl --user daemon-reload
+	@echo "Service uninstalled."
+
+enable-service: install-service
+	@echo "Enabling and starting service..."
+	systemctl --user enable aw-watcher-ask-away
+	systemctl --user start aw-watcher-ask-away
+	@echo "Service status:"
+	@systemctl --user status aw-watcher-ask-away --no-pager
+
+disable-service:
+	@echo "Disabling and stopping service..."
+	systemctl --user stop aw-watcher-ask-away
+	systemctl --user disable aw-watcher-ask-away
+	@echo "Service disabled."
+
+setup-wayland: enable-service
+	@echo "Configuring Wayland environment import..."
+	@echo ""
+	@echo "Detecting compositor configuration files..."
+	@if [ -f ~/.config/sway/config ]; then \
+		echo "Found Sway config at ~/.config/sway/config"; \
+		if grep -q "systemctl --user import-environment WAYLAND_DISPLAY" ~/.config/sway/config; then \
+			echo "✓ Environment import already configured"; \
+		else \
+			echo "" >> ~/.config/sway/config; \
+			echo "# Import WAYLAND_DISPLAY for systemd services" >> ~/.config/sway/config; \
+			echo "exec systemctl --user import-environment WAYLAND_DISPLAY" >> ~/.config/sway/config; \
+			echo "✓ Added environment import to Sway config"; \
+			echo "  Please reload Sway config or log out and back in"; \
+		fi; \
+	elif [ -f ~/.config/hypr/hyprland.conf ]; then \
+		echo "Found Hyprland config at ~/.config/hypr/hyprland.conf"; \
+		if grep -q "systemctl --user import-environment WAYLAND_DISPLAY" ~/.config/hypr/hyprland.conf; then \
+			echo "✓ Environment import already configured"; \
+		else \
+			echo "" >> ~/.config/hypr/hyprland.conf; \
+			echo "# Import WAYLAND_DISPLAY for systemd services" >> ~/.config/hypr/hyprland.conf; \
+			echo "exec-once = systemctl --user import-environment WAYLAND_DISPLAY" >> ~/.config/hypr/hyprland.conf; \
+			echo "✓ Added environment import to Hyprland config"; \
+			echo "  Please reload Hyprland config or log out and back in"; \
+		fi; \
+	else \
+		echo "Could not detect compositor config file."; \
+		echo ""; \
+		echo "Please manually add this line to your compositor startup:"; \
+		echo "  exec systemctl --user import-environment WAYLAND_DISPLAY"; \
+		echo ""; \
+		echo "Common locations:"; \
+		echo "  - Sway: ~/.config/sway/config"; \
+		echo "  - Hyprland: ~/.config/hypr/hyprland.conf"; \
+		echo "  - Others: check your compositor documentation"; \
+	fi
+	@echo ""
+	@echo "Restarting service to pick up environment changes..."
+	@systemctl --user restart aw-watcher-ask-away 2>/dev/null || echo "Note: Service restart will happen after compositor reload"
+	@echo ""
+	@echo "⚠ IMPORTANT: The environment variable will only be available after:"
+	@echo "  1. Reloading your compositor config, OR"
+	@echo "  2. Logging out and back in"
+	@echo ""
+	@echo "After that, verify the service is working:"
+	@echo "  systemctl --user status aw-watcher-ask-away"
+
+uninstall:
+	pipx uninstall aw-watcher-ask-away 2>/dev/null || true
+	@echo "Package uninstalled."

--- a/README.md
+++ b/README.md
@@ -59,6 +59,45 @@ For Wayland, manually add to your compositor config:
 exec systemctl --user import-environment WAYLAND_DISPLAY
 ```
 
+## Configuration
+
+The watcher can be configured via a config file or command-line arguments. Command-line arguments override config file settings.
+
+### Config File
+
+Configuration is stored in the ActivityWatch standard location:
+```
+~/.config/activitywatch/aw-watcher-ask-away/aw-watcher-ask-away.toml
+```
+
+Example configuration:
+```toml
+# Number of minutes to look into the past for events
+depth = 10.0
+
+# Number of seconds to wait before checking for AFK events again
+frequency = 5.0
+
+# Number of minutes you need to be away before reporting on it
+length = 5.0
+```
+
+The config file is created automatically with default values on first run if it doesn't exist.
+
+### Command-line Arguments
+
+You can override config file settings using command-line arguments:
+```console
+aw-watcher-ask-away --depth 15 --frequency 10 --length 3
+```
+
+Available options:
+- `--depth`: Minutes to look into the past for events (default: from config or 10)
+- `--frequency`: Seconds between AFK event checks (default: from config or 5)
+- `--length`: Minimum AFK minutes before prompting (default: from config or 5)
+- `--testing`: Run in testing mode
+- `--verbose`: Enable verbose logging
+
 ## Roadmap
 
 Most of the improvements involve a more complicated pop-up window.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,50 @@ pipx install aw-watcher-ask-away
 
 ([Need to install `pipx` first?](https://pypa.github.io/pipx/installation/))
 
+## Running
+
+### Recommended: Using aw-qt
+
+The recommended way to run this watcher is through [aw-qt](https://github.com/ActivityWatch/aw-qt), which manages both the server and watchers automatically. After installing aw-watcher-ask-away, aw-qt should detect and start it automatically.
+
+### Alternative: Manual Start
+
+If not using aw-qt, you can run it manually:
+```console
+aw-watcher-ask-away
+```
+
+Make sure `aw-server` and `aw-watcher-afk` are running first, as this watcher monitors AFK events.
+
+### Alternative: systemd (Linux)
+
+For users not using aw-qt who want automatic startup via systemd:
+
+**Quick setup with Makefile:**
+```console
+make enable-service
+```
+
+**For Wayland users, also run:**
+```console
+make setup-wayland
+```
+
+This automatically configures your compositor to import the WAYLAND_DISPLAY environment variable.
+
+**Manual setup (if preferred):**
+```console
+cp misc/aw-watcher-ask-away.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable aw-watcher-ask-away.service
+systemctl --user start aw-watcher-ask-away.service
+```
+
+For Wayland, manually add to your compositor config:
+```
+exec systemctl --user import-environment WAYLAND_DISPLAY
+```
+
 ## Roadmap
 
 Most of the improvements involve a more complicated pop-up window.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ Available options:
 - `--testing`: Run in testing mode
 - `--verbose`: Enable verbose logging
 
+### Lid Watcher Integration (Optional)
+
+This watcher can integrate with [aw-watcher-lid](https://github.com/tobixen/aw-watcher-lid) to also prompt you about laptop lid closures and system suspends, not just regular AFK periods.
+
+**Why use both watchers?**
+- Regular AFK: Detects when you step away from keyboard but leave computer running
+- Lid events: Provides exact timestamps for when you close/open your laptop lid or suspend/resume the system
+- Combined: More complete picture of when you're away from your computer
+
+**Setup:**
+1. Install aw-watcher-lid: `pipx install aw-watcher-lid`
+2. Start it (see [aw-watcher-lid README](https://github.com/tobixen/aw-watcher-lid#readme) for setup)
+3. aw-watcher-ask-away will automatically detect and use it
+
+**To disable lid integration:**
+Set `enable_lid_events = false` in your config file.
+
+**Note:** aw-watcher-lid is an optional third-party watcher, not part of the standard ActivityWatch distribution.
+
 ## Roadmap
 
 Most of the improvements involve a more complicated pop-up window.

--- a/README.md
+++ b/README.md
@@ -46,19 +46,6 @@ make setup-wayland
 
 This automatically configures your compositor to import the WAYLAND_DISPLAY environment variable.
 
-**Manual setup (if preferred):**
-```console
-cp misc/aw-watcher-ask-away.service ~/.config/systemd/user/
-systemctl --user daemon-reload
-systemctl --user enable aw-watcher-ask-away.service
-systemctl --user start aw-watcher-ask-away.service
-```
-
-For Wayland, manually add to your compositor config:
-```
-exec systemctl --user import-environment WAYLAND_DISPLAY
-```
-
 ## Configuration
 
 The watcher can be configured via a config file or command-line arguments. Command-line arguments override config file settings.
@@ -68,18 +55,6 @@ The watcher can be configured via a config file or command-line arguments. Comma
 Configuration is stored in the ActivityWatch standard location:
 ```
 ~/.config/activitywatch/aw-watcher-ask-away/aw-watcher-ask-away.toml
-```
-
-Example configuration:
-```toml
-# Number of minutes to look into the past for events
-depth = 10.0
-
-# Number of seconds to wait before checking for AFK events again
-frequency = 5.0
-
-# Number of minutes you need to be away before reporting on it
-length = 5.0
 ```
 
 The config file is created automatically with default values on first run if it doesn't exist.

--- a/misc/aw-watcher-ask-away.service
+++ b/misc/aw-watcher-ask-away.service
@@ -1,0 +1,50 @@
+########################################
+# aw-watcher-ask-away.service         #
+########################################
+#
+# This service file provides an alternative way to run aw-watcher-ask-away
+# without using aw-qt. The recommended approach is to use aw-qt, which manages
+# both the server and watchers automatically.
+#
+# This watcher shows GUI dialogs when you return from AFK, so it needs access
+# to your display server.
+#
+# Prerequisites:
+# - aw-server must be installed and running
+# - aw-watcher-afk must be running (ask-away monitors AFK events)
+# - This watcher must be installed (pip install aw-watcher-ask-away)
+#
+# Installation for X11 users:
+# 1. Copy service file: cp misc/aw-watcher-ask-away.service ~/.config/systemd/user/
+# 2. Reload systemd: systemctl --user daemon-reload
+# 3. Enable the service: systemctl --user enable aw-watcher-ask-away.service
+# 4. Start the service: systemctl --user start aw-watcher-ask-away.service
+#
+# Additional setup for Wayland users:
+# - Add to your compositor startup script (e.g., ~/.config/sway/config):
+#   exec systemctl --user import-environment WAYLAND_DISPLAY
+# - This ensures the service can access your Wayland display
+#
+# The watcher will automatically retry connection to aw-server if it's not ready yet.
+#
+
+[Unit]
+Description=ActivityWatch AFK Questionnaire Watcher
+Documentation=https://github.com/Jeremiah-England/aw-watcher-ask-away
+After=aw-server.service
+# Ensure we run within a graphical session
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=aw-watcher-ask-away
+Restart=on-failure
+RestartSec=10
+Environment=PYTHONUNBUFFERED=1
+# Set DISPLAY for X11 users (Wayland users should import WAYLAND_DISPLAY)
+Environment="DISPLAY=:0"
+# Note: For Wayland, also run: systemctl --user import-environment WAYLAND_DISPLAY
+# Add this command to your compositor/session startup script
+
+[Install]
+WantedBy=default.target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
-dependencies = ["aw-client", "appdirs"]
+dependencies = ["aw-client", "aw-core", "appdirs"]
 
 [project.scripts]
 aw-watcher-ask-away = "aw_watcher_ask_away.__main__:main"

--- a/src/aw_watcher_ask_away/__main__.py
+++ b/src/aw_watcher_ask_away/__main__.py
@@ -28,7 +28,7 @@ def prompt(event: aw_core.Event, recent_events: Iterable[aw_core.Event]):
     prompt = f"What were you doing from {start_time_str} - {end_time_str} ({event.duration.seconds / 60:.1f} minutes)?"
     title = "AFK Checkin"
 
-    return aw_dialog.ask_string(title, prompt, [event.data[DATA_KEY] for event in recent_events])
+    return aw_dialog.ask_string(title, prompt, [event.data.get(DATA_KEY, '') for event in recent_events])
 
 
 def get_state_retries(client: ActivityWatchClient, enable_lid_events: bool = True):

--- a/src/aw_watcher_ask_away/__main__.py
+++ b/src/aw_watcher_ask_away/__main__.py
@@ -10,6 +10,7 @@ from aw_core.log import setup_logging
 from requests.exceptions import ConnectionError
 
 import aw_watcher_ask_away.dialog as aw_dialog
+from aw_watcher_ask_away.config import load_config
 from aw_watcher_ask_away.core import (
     DATA_KEY,
     LOCAL_TIMEZONE,
@@ -47,15 +48,27 @@ def get_state_retries(client: ActivityWatchClient):
 
 
 def main():
+    # Load config from file (falls back to defaults if file doesn't exist)
+    config = load_config()
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--depth", type=float, default=10, help="The number of minutes to look into the past for events."
+        "--depth",
+        type=float,
+        default=config.get("depth", 10),
+        help="The number of minutes to look into the past for events. (default: from config or 10)",
     )
     parser.add_argument(
-        "--frequency", type=float, default=5, help="The number of seconds to wait before checking for AFK events again."
+        "--frequency",
+        type=float,
+        default=config.get("frequency", 5),
+        help="The number of seconds to wait before checking for AFK events again. (default: from config or 5)",
     )
     parser.add_argument(
-        "--length", type=float, default=5, help="The number of minutes you need to be away before reporting on it."
+        "--length",
+        type=float,
+        default=config.get("length", 5),
+        help="The number of minutes you need to be away before reporting on it. (default: from config or 5)",
     )
     parser.add_argument("--testing", action="store_true", help="Run in testing mode.")
     parser.add_argument("--verbose", action="store_true", help="I want to see EVERYTHING!")

--- a/src/aw_watcher_ask_away/__main__.py
+++ b/src/aw_watcher_ask_away/__main__.py
@@ -31,7 +31,7 @@ def prompt(event: aw_core.Event, recent_events: Iterable[aw_core.Event]):
     return aw_dialog.ask_string(title, prompt, [event.data[DATA_KEY] for event in recent_events])
 
 
-def get_state_retries(client: ActivityWatchClient):
+def get_state_retries(client: ActivityWatchClient, enable_lid_events: bool = True):
     """When the computer is starting up sometimes the aw-server is not ready for requests yet.
 
     So we sit and retry for a while before giving up.
@@ -40,7 +40,7 @@ def get_state_retries(client: ActivityWatchClient):
         try:
             # This works because the constructor of AWAskAwayState tries to get bucket names.
             # If it didn't we'd need to do something else here.
-            return AWAskAwayClient(client)
+            return AWAskAwayClient(client, enable_lid_events=enable_lid_events)
         except ConnectionError:
             logger.exception("Cannot connect to client.")
             time.sleep(10)  # 10 * 10 = wait for 100s before giving up.
@@ -88,7 +88,7 @@ def main():
             client_name=WATCHER_NAME, testing=args.testing
         )
         with client:
-            state = get_state_retries(client)
+            state = get_state_retries(client, enable_lid_events=config.get("enable_lid_events", True))
             logger.info("Successfully connected to the server.")
 
             while True:

--- a/src/aw_watcher_ask_away/config.py
+++ b/src/aw_watcher_ask_away/config.py
@@ -11,6 +11,12 @@ frequency = 5.0
 
 # Number of minutes you need to be away before reporting on it
 length = 5.0
+
+# Enable integration with aw-watcher-lid for lid/suspend events
+# OPTIONAL: Requires aw-watcher-lid to be installed and running
+# See: https://github.com/tobixen/aw-watcher-lid
+# When enabled, you'll be prompted about lid closures in addition to regular AFK
+enable_lid_events = true
 """.strip()
 
 

--- a/src/aw_watcher_ask_away/config.py
+++ b/src/aw_watcher_ask_away/config.py
@@ -1,0 +1,22 @@
+"""Configuration management for aw-watcher-ask-away."""
+
+from aw_core.config import load_config_toml
+
+DEFAULT_CONFIG = """
+# Number of minutes to look into the past for events
+depth = 10.0
+
+# Number of seconds to wait before checking for AFK events again
+frequency = 5.0
+
+# Number of minutes you need to be away before reporting on it
+length = 5.0
+""".strip()
+
+
+def load_config() -> dict:
+    """Load configuration using ActivityWatch standard approach.
+
+    Config location: ~/.config/activitywatch/aw-watcher-ask-away/aw-watcher-ask-away.toml
+    """
+    return load_config_toml("aw-watcher-ask-away", DEFAULT_CONFIG)

--- a/src/aw_watcher_ask_away/core.py
+++ b/src/aw_watcher_ask_away/core.py
@@ -136,10 +136,11 @@ class AWAskAwayClient:
                 except HTTPError:
                     logger.warning("Failed to get lid events, continuing with AFK events only")
 
-            # Merge events from both sources
-            all_events = afk_events + lid_events
+            # Merge and sort events from both sources by timestamp (most recent first)
+            all_events = aw_transform.sort_by_timestamp(afk_events + lid_events)
 
             # Check if currently AFK (from either source)
+            # Most recent event is first after sorting
             if all_events and is_afk(all_events[0]):
                 # Currently AFK, wait to bring up the prompt
                 return

--- a/src/aw_watcher_ask_away/core.py
+++ b/src/aw_watcher_ask_away/core.py
@@ -136,14 +136,18 @@ class AWAskAwayClient:
                 except HTTPError:
                     logger.warning("Failed to get lid events, continuing with AFK events only")
 
-            # Merge and sort events from both sources by timestamp (most recent first)
+            # Merge and sort events from both sources by timestamp
+            # Note: sort_by_timestamp() sorts in ASCENDING order (oldest first)
             all_events = aw_transform.sort_by_timestamp(afk_events + lid_events)
 
             # Check if currently AFK (from either source)
-            # Most recent event is first after sorting
-            if all_events and is_afk(all_events[0]):
-                # Currently AFK, wait to bring up the prompt
-                return
+            # Most recent event is LAST after sorting (ascending order)
+            if all_events:
+                most_recent = all_events[-1]  # Last element is most recent
+                currently_afk = is_afk(most_recent)
+                if currently_afk:
+                    # Currently AFK, wait to bring up the prompt
+                    return
 
             yield from self.state.get_unseen_afk_events(all_events, seconds, durration_thresh)
         except HTTPError:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,61 @@
+"""Tests for configuration loading."""
+
+from unittest.mock import patch
+
+from aw_watcher_ask_away.config import DEFAULT_CONFIG, load_config
+
+
+def test_default_config_has_expected_keys() -> None:
+    """Test that DEFAULT_CONFIG contains all expected configuration keys."""
+    # Parse the default config string to check it's valid TOML
+    import tomllib
+
+    config = tomllib.loads(DEFAULT_CONFIG)
+
+    assert "depth" in config
+    assert "frequency" in config
+    assert "length" in config
+
+
+def test_default_config_values() -> None:
+    """Test that DEFAULT_CONFIG has expected default values."""
+    import tomllib
+
+    config = tomllib.loads(DEFAULT_CONFIG)
+
+    assert config["depth"] == 10.0
+    assert config["frequency"] == 5.0
+    assert config["length"] == 5.0
+
+
+def test_load_config_returns_defaults_when_no_file() -> None:
+    """Test that load_config returns defaults when config file doesn't exist."""
+    # Mock aw_core.config.load_config_toml to return parsed defaults
+    with patch("aw_watcher_ask_away.config.load_config_toml") as mock_load:
+        import tomllib
+
+        mock_load.return_value = tomllib.loads(DEFAULT_CONFIG)
+
+        config = load_config()
+
+        # Verify load_config_toml was called with correct arguments
+        mock_load.assert_called_once_with("aw-watcher-ask-away", DEFAULT_CONFIG)
+
+        # Verify returned config has expected values
+        assert config["depth"] == 10.0
+        assert config["frequency"] == 5.0
+        assert config["length"] == 5.0
+
+
+def test_load_config_returns_custom_values() -> None:
+    """Test that load_config returns custom values when config file exists."""
+    custom_config = {"depth": 15.0, "frequency": 10.0, "length": 3.0}
+
+    with patch("aw_watcher_ask_away.config.load_config_toml") as mock_load:
+        mock_load.return_value = custom_config
+
+        config = load_config()
+
+        assert config["depth"] == 15.0
+        assert config["frequency"] == 10.0
+        assert config["length"] == 3.0

--- a/tests/test_lid_integration.py
+++ b/tests/test_lid_integration.py
@@ -1,0 +1,56 @@
+"""Tests for lid watcher integration."""
+
+import aw_core
+import pytest
+
+from aw_watcher_ask_away.core import AWWatcherAskAwayError, find_lid_bucket, is_afk
+
+
+def test_find_lid_bucket_found() -> None:
+    """Test finding lid bucket when it exists."""
+    buckets = {
+        "aw-watcher-afk_hostname": {},
+        "aw-watcher-lid_hostname": {},
+    }
+
+    lid_bucket = find_lid_bucket(buckets)
+    assert lid_bucket == "aw-watcher-lid_hostname"
+
+
+def test_find_lid_bucket_not_found() -> None:
+    """Test finding lid bucket when it doesn't exist."""
+    buckets = {
+        "aw-watcher-afk_hostname": {},
+    }
+
+    lid_bucket = find_lid_bucket(buckets)
+    assert lid_bucket is None
+
+
+def test_find_lid_bucket_multiple() -> None:
+    """Test error when multiple lid buckets found."""
+    buckets = {
+        "aw-watcher-lid_hostname1": {},
+        "aw-watcher-lid_hostname2": {},
+    }
+
+    with pytest.raises(AWWatcherAskAwayError, match="too many lid buckets"):
+        find_lid_bucket(buckets)
+
+
+def test_is_afk_regular() -> None:
+    """Test is_afk with regular AFK event."""
+    event = aw_core.Event(data={"status": "afk"})
+    assert is_afk(event) is True
+
+
+def test_is_afk_system() -> None:
+    """Test is_afk with system-afk event from lid watcher."""
+    event = aw_core.Event(data={"status": "system-afk"})
+    assert is_afk(event) is True
+
+
+def test_is_afk_not_afk() -> None:
+    """Test is_afk with not-afk event."""
+    event = aw_core.Event(data={"status": "not-afk"})
+    assert is_afk(event) is False


### PR DESCRIPTION
## Summary
This PR includes two features:
1. **Config file support** (from PR #2)
2. **Lid watcher integration** (new)

## Part 1: Config File Support
Add configuration file support using ActivityWatch standard `aw_core.config` patterns.

### Changes
- New `config.py` module with default configuration
- Config file location: `~/.config/activitywatch/aw-watcher-ask-away/aw-watcher-ask-away.toml`
- Configurable parameters: `depth`, `frequency`, `length`
- CLI arguments override config file settings
- Added `aw-core` dependency to pyproject.toml
- 4 tests for config loading

## Part 2: Lid Watcher Integration
Add integration with [aw-watcher-lid](https://github.com/tobixen/aw-watcher-lid) to also prompt users about laptop lid closures and system suspends.

### Why?
- **Regular AFK**: Detects when you step away but leave computer running
- **Lid events**: Exact timestamps for lid close/open and suspend/resume  
- **Combined**: Complete picture of away time (OR logic, not AND)

### Features
- Fetches and merges events from both aw-watcher-afk and aw-watcher-lid
- Handles both `afk` and `system-afk` event statuses
- Configurable via `enable_lid_events` config option (default: true)
- Gracefully handles when aw-watcher-lid is not installed (optional)
- Events properly sorted by timestamp before checking current state
- 6 new tests for lid integration

## Testing
- ✅ All 13 tests pass (4 config + 6 lid + 3 existing)
- ✅ Manual testing confirmed: prompts for lid closure gaps
- ✅ Config file creation verified
- ✅ Syntax validated

## Documentation
- README updated with Configuration section and Lid Watcher Integration section
- Config file includes clear comments about optional lid watcher
- Links to aw-watcher-lid repo provided

**Note:** aw-watcher-lid is an optional third-party watcher created by @tobixen, not part of standard ActivityWatch.

**Note:** PR #2 is now superseded by this PR which includes both features.

DISCLAIMER: This PR was AI-generated and manually tested.