### PR TITLE
Feature: split afk periods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,148 @@
+.PHONY: help install install-dev install-all test lint format clean uninstall install-service uninstall-service enable-service disable-service setup-wayland
+
+help:
+	@echo "Available targets:"
+	@echo "  install-all       - Complete setup (install + enable service)"
+	@echo "  install           - Install the package using pipx"
+	@echo "  install-dev       - Install with development dependencies"
+	@echo "  test              - Run tests"
+	@echo "  lint              - Run linting (ruff check)"
+	@echo "  format            - Format code (ruff format)"
+	@echo "  clean             - Remove build artifacts and cache"
+	@echo "  install-service   - Install systemd user service"
+	@echo "  uninstall-service - Uninstall systemd user service"
+	@echo "  enable-service    - Install and enable the service"
+	@echo "  disable-service   - Disable and stop the service"
+	@echo "  setup-wayland     - Configure Wayland environment import"
+	@echo "  uninstall         - Uninstall the package"
+	@echo "WARNING: This large amount of targets was made by an eager AI-bot"
+	@echo "Only enable-service and setup-wayland has been tested, the latter with sway"
+
+install:
+	pipx install .
+	@echo ""
+	@echo "✓ aw-watcher-ask-away installed successfully!"
+	@echo ""
+	@echo "Next steps:"
+	@echo "  1. Recommended: Use aw-qt (ActivityWatch GUI)"
+	@echo "     aw-qt will detect and start this watcher automatically"
+	@echo ""
+	@echo "  2. Alternative: Run as systemd service"
+	@echo "     make enable-service"
+	@echo ""
+	@echo "  3. For Wayland users running systemd:"
+	@echo "     make setup-wayland"
+	@echo ""
+	@echo "  4. Test manually:"
+	@echo "     aw-watcher-ask-away"
+	@echo ""
+
+install-dev:
+	pip install -e ".[dev]"
+
+install-all: install enable-service
+	@echo ""
+	@echo "✓ Installation complete!"
+	@echo "  The watcher is now installed and running as a systemd service."
+	@echo ""
+	@echo "Check status with: systemctl --user status aw-watcher-ask-away"
+	@echo "View logs with:    journalctl --user -u aw-watcher-ask-away -f"
+	@echo ""
+	@echo "Note: Wayland users should also run: make setup-wayland"
+
+test:
+	pytest tests/ -v
+
+lint:
+	ruff check .
+
+format:
+	ruff format .
+
+clean:
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".ruff_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name "*.pyc" -delete
+	rm -rf dist/ build/
+
+install-service:
+	@echo "Installing systemd user service..."
+	mkdir -p ~/.config/systemd/user
+	cp misc/aw-watcher-ask-away.service ~/.config/systemd/user/
+	systemctl --user daemon-reload
+	@echo "Service installed. Use 'make enable-service' to enable and start it."
+
+uninstall-service:
+	@echo "Uninstalling systemd user service..."
+	systemctl --user stop aw-watcher-ask-away 2>/dev/null || true
+	systemctl --user disable aw-watcher-ask-away 2>/dev/null || true
+	rm -f ~/.config/systemd/user/aw-watcher-ask-away.service
+	systemctl --user daemon-reload
+	@echo "Service uninstalled."
+
+enable-service: install-service
+	@echo "Enabling and starting service..."
+	systemctl --user enable aw-watcher-ask-away
+	systemctl --user start aw-watcher-ask-away
+	@echo "Service status:"
+	@systemctl --user status aw-watcher-ask-away --no-pager
+
+disable-service:
+	@echo "Disabling and stopping service..."
+	systemctl --user stop aw-watcher-ask-away
+	systemctl --user disable aw-watcher-ask-away
+	@echo "Service disabled."
+
+setup-wayland: enable-service
+	@echo "Configuring Wayland environment import..."
+	@echo ""
+	@echo "Detecting compositor configuration files..."
+	@if [ -f ~/.config/sway/config ]; then \
+		echo "Found Sway config at ~/.config/sway/config"; \
+		if grep -q "systemctl --user import-environment WAYLAND_DISPLAY" ~/.config/sway/config; then \
+			echo "✓ Environment import already configured"; \
+		else \
+			echo "" >> ~/.config/sway/config; \
+			echo "# Import WAYLAND_DISPLAY for systemd services" >> ~/.config/sway/config; \
+			echo "exec systemctl --user import-environment WAYLAND_DISPLAY" >> ~/.config/sway/config; \
+			echo "✓ Added environment import to Sway config"; \
+			echo "  Please reload Sway config or log out and back in"; \
+		fi; \
+	elif [ -f ~/.config/hypr/hyprland.conf ]; then \
+		echo "Found Hyprland config at ~/.config/hypr/hyprland.conf"; \
+		if grep -q "systemctl --user import-environment WAYLAND_DISPLAY" ~/.config/hypr/hyprland.conf; then \
+			echo "✓ Environment import already configured"; \
+		else \
+			echo "" >> ~/.config/hypr/hyprland.conf; \
+			echo "# Import WAYLAND_DISPLAY for systemd services" >> ~/.config/hypr/hyprland.conf; \
+			echo "exec-once = systemctl --user import-environment WAYLAND_DISPLAY" >> ~/.config/hypr/hyprland.conf; \
+			echo "✓ Added environment import to Hyprland config"; \
+			echo "  Please reload Hyprland config or log out and back in"; \
+		fi; \
+	else \
+		echo "Could not detect compositor config file."; \
+		echo ""; \
+		echo "Please manually add this line to your compositor startup:"; \
+		echo "  exec systemctl --user import-environment WAYLAND_DISPLAY"; \
+		echo ""; \
+		echo "Common locations:"; \
+		echo "  - Sway: ~/.config/sway/config"; \
+		echo "  - Hyprland: ~/.config/hypr/hyprland.conf"; \
+		echo "  - Others: check your compositor documentation"; \
+	fi
+	@echo ""
+	@echo "Restarting service to pick up environment changes..."
+	@systemctl --user restart aw-watcher-ask-away 2>/dev/null || echo "Note: Service restart will happen after compositor reload"
+	@echo ""
+	@echo "⚠ IMPORTANT: The environment variable will only be available after:"
+	@echo "  1. Reloading your compositor config, OR"
+	@echo "  2. Logging out and back in"
+	@echo ""
+	@echo "After that, verify the service is working:"
+	@echo "  systemctl --user status aw-watcher-ask-away"
+
+uninstall:
+	pipx uninstall aw-watcher-ask-away 2>/dev/null || true
+	@echo "Package uninstalled."

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,20 @@ help:
 	@echo "Only enable-service and setup-wayland has been tested, the latter with sway"
 
 install:
+	@command -v pipx >/dev/null 2>&1 || { \
+		echo "Error: pipx is not installed"; \
+		echo ""; \
+		echo "Please install pipx first:"; \
+		echo "  https://pypa.github.io/pipx/installation/"; \
+		echo ""; \
+		echo "Quick install options:"; \
+		echo "  - Arch Linux: sudo pacman -S python-pipx"; \
+		echo "  - Debian/Ubuntu: sudo apt install pipx"; \
+		echo "  - Fedora: sudo dnf install pipx"; \
+		echo "  - macOS: brew install pipx"; \
+		echo "  - pip: python3 -m pip install --user pipx"; \
+		exit 1; \
+	}
 	pipx install .
 	@echo ""
 	@echo "✓ aw-watcher-ask-away installed successfully!"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,45 @@ For Wayland, manually add to your compositor config:
 exec systemctl --user import-environment WAYLAND_DISPLAY
 ```
 
+## Configuration
+
+The watcher can be configured via a config file or command-line arguments. Command-line arguments override config file settings.
+
+### Config File
+
+Configuration is stored in the ActivityWatch standard location:
+```
+~/.config/activitywatch/aw-watcher-ask-away/aw-watcher-ask-away.toml
+```
+
+Example configuration:
+```toml
+# Number of minutes to look into the past for events
+depth = 10.0
+
+# Number of seconds to wait before checking for AFK events again
+frequency = 5.0
+
+# Number of minutes you need to be away before reporting on it
+length = 5.0
+```
+
+The config file is created automatically with default values on first run if it doesn't exist.
+
+### Command-line Arguments
+
+You can override config file settings using command-line arguments:
+```console
+aw-watcher-ask-away --depth 15 --frequency 10 --length 3
+```
+
+Available options:
+- `--depth`: Minutes to look into the past for events (default: from config or 10)
+- `--frequency`: Seconds between AFK event checks (default: from config or 5)
+- `--length`: Minimum AFK minutes before prompting (default: from config or 5)
+- `--testing`: Run in testing mode
+- `--verbose`: Enable verbose logging
+
 ## Roadmap
 
 Most of the improvements involve a more complicated pop-up window.

--- a/README.md
+++ b/README.md
@@ -78,9 +78,8 @@ Available options:
 This watcher can integrate with [aw-watcher-lid](https://github.com/tobixen/aw-watcher-lid) to also prompt you about laptop lid closures and system suspends, not just regular AFK periods.
 
 **Why use both watchers?**
-- Regular AFK: Detects when you step away from keyboard but leave computer running
-- Lid events: Provides exact timestamps for when you close/open your laptop lid or suspend/resume the system
-- Combined: More complete picture of when you're away from your computer
+
+Lid events may sometimes be more accurate than the ordinary afk watcher (particularly for short-lived afk events), but won't catch cases where the laptop is left with the lid open, as well as when someone leaves the desktop computer.
 
 **Setup:**
 1. Install aw-watcher-lid: `pipx install aw-watcher-lid`
@@ -88,9 +87,13 @@ This watcher can integrate with [aw-watcher-lid](https://github.com/tobixen/aw-w
 3. aw-watcher-ask-away will automatically detect and use it
 
 **To disable lid integration:**
-Set `enable_lid_events = false` in your config file.
+I.e. if having an external keyboard it's possible to close the lid without being AFK.  Set `enable_lid_events = false` in your config file - or skip installing the aw-watcher-lid.
 
-**Note:** aw-watcher-lid is an optional third-party watcher, not part of the standard ActivityWatch distribution.
+## Features
+
+### Split AFK Periods
+
+Quite often one ends up doing multiple tasks in my afk periods, for instance it could be "lunch" for 20 minutes and "phone call" for 10 minutes.  The pop-up dialog has a **Split** button for splitting the afk time on multiple event lines.  You can add as many lines as needed and then edit either the start time or the duration of the event lines.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,50 @@ pipx install aw-watcher-ask-away
 
 ([Need to install `pipx` first?](https://pypa.github.io/pipx/installation/))
 
+## Running
+
+### Recommended: Using aw-qt
+
+The recommended way to run this watcher is through [aw-qt](https://github.com/ActivityWatch/aw-qt), which manages both the server and watchers automatically. After installing aw-watcher-ask-away, aw-qt should detect and start it automatically.
+
+### Alternative: Manual Start
+
+If not using aw-qt, you can run it manually:
+```console
+aw-watcher-ask-away
+```
+
+Make sure `aw-server` and `aw-watcher-afk` are running first, as this watcher monitors AFK events.
+
+### Alternative: systemd (Linux)
+
+For users not using aw-qt who want automatic startup via systemd:
+
+**Quick setup with Makefile:**
+```console
+make enable-service
+```
+
+**For Wayland users, also run:**
+```console
+make setup-wayland
+```
+
+This automatically configures your compositor to import the WAYLAND_DISPLAY environment variable.
+
+**Manual setup (if preferred):**
+```console
+cp misc/aw-watcher-ask-away.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable aw-watcher-ask-away.service
+systemctl --user start aw-watcher-ask-away.service
+```
+
+For Wayland, manually add to your compositor config:
+```
+exec systemctl --user import-environment WAYLAND_DISPLAY
+```
+
 ## Roadmap
 
 Most of the improvements involve a more complicated pop-up window.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ Available options:
 - `--testing`: Run in testing mode
 - `--verbose`: Enable verbose logging
 
+### Lid Watcher Integration (Optional)
+
+This watcher can integrate with [aw-watcher-lid](https://github.com/tobixen/aw-watcher-lid) to also prompt you about laptop lid closures and system suspends, not just regular AFK periods.
+
+**Why use both watchers?**
+- Regular AFK: Detects when you step away from keyboard but leave computer running
+- Lid events: Provides exact timestamps for when you close/open your laptop lid or suspend/resume the system
+- Combined: More complete picture of when you're away from your computer
+
+**Setup:**
+1. Install aw-watcher-lid: `pipx install aw-watcher-lid`
+2. Start it (see [aw-watcher-lid README](https://github.com/tobixen/aw-watcher-lid#readme) for setup)
+3. aw-watcher-ask-away will automatically detect and use it
+
+**To disable lid integration:**
+Set `enable_lid_events = false` in your config file.
+
+**Note:** aw-watcher-lid is an optional third-party watcher, not part of the standard ActivityWatch distribution.
+
 ## Roadmap
 
 Most of the improvements involve a more complicated pop-up window.

--- a/README.md
+++ b/README.md
@@ -46,19 +46,6 @@ make setup-wayland
 
 This automatically configures your compositor to import the WAYLAND_DISPLAY environment variable.
 
-**Manual setup (if preferred):**
-```console
-cp misc/aw-watcher-ask-away.service ~/.config/systemd/user/
-systemctl --user daemon-reload
-systemctl --user enable aw-watcher-ask-away.service
-systemctl --user start aw-watcher-ask-away.service
-```
-
-For Wayland, manually add to your compositor config:
-```
-exec systemctl --user import-environment WAYLAND_DISPLAY
-```
-
 ## Configuration
 
 The watcher can be configured via a config file or command-line arguments. Command-line arguments override config file settings.
@@ -68,18 +55,6 @@ The watcher can be configured via a config file or command-line arguments. Comma
 Configuration is stored in the ActivityWatch standard location:
 ```
 ~/.config/activitywatch/aw-watcher-ask-away/aw-watcher-ask-away.toml
-```
-
-Example configuration:
-```toml
-# Number of minutes to look into the past for events
-depth = 10.0
-
-# Number of seconds to wait before checking for AFK events again
-frequency = 5.0
-
-# Number of minutes you need to be away before reporting on it
-length = 5.0
 ```
 
 The config file is created automatically with default values on first run if it doesn't exist.

--- a/docs/FEATURE_SPLIT_AFK_PERIODS.md
+++ b/docs/FEATURE_SPLIT_AFK_PERIODS.md
@@ -1,0 +1,369 @@
+# Feature Specification: Split AFK Periods
+
+## Overview
+
+Allow users to split a single AFK period into multiple activities with different descriptions and time allocations.
+
+## Background
+
+Currently, when a user returns from an extended AFK period during which they performed multiple activities, they can only enter a single description for the entire period. This feature enables users to split the AFK period into multiple segments, each with its own description and duration.
+
+## User Stories
+
+1. **As a user**, I want to split a 30-minute AFK period into "lunch" (20 min) and "phone call" (10 min), so that my time tracking accurately reflects what I did.
+
+2. **As a user**, I want to easily add or remove activity segments without manually calculating time adjustments, so that I can quickly log my activities.
+
+3. **As a user**, I want the time calculations to remain consistent, so that the total duration always matches my actual AFK period.
+
+4. **As a developer**, I want to test the split dialog without waiting for an actual AFK period, so that I can verify functionality quickly.
+
+## Functional Requirements
+
+### FR1: Split Button
+
+**Description**: Add a "Split" button to the main dialog that expands the interface to show multiple activity lines.
+
+**Acceptance Criteria**:
+- Button labeled "Split" appears in the main dialog (next to OK/Cancel/Settings)
+- Clicking "Split" expands the dialog to show split mode
+- In split mode, the single entry field is replaced with multiple activity lines
+- Removing all extra lines (down to 1 line) automatically exits split mode and returns to normal single-entry mode
+
+### FR2: Activity Lines
+
+**Description**: Each activity line represents a time segment with description, start time, and duration.
+
+**Acceptance Criteria**:
+- Each line displays:
+  - Activity description (text entry field)
+  - Start time (HH:MM format, read-only for first line, editable for others)
+  - Duration in minutes (numeric input, editable)
+- First line's start time is fixed to the AFK period's start time (not editable)
+- All other fields are editable
+- Minimum 2 lines when in split mode
+- Maximum 20 lines (reasonable limit)
+
+### FR3: Add/Remove Lines
+
+**Description**: Users can dynamically add or remove activity lines.
+
+**Acceptance Criteria**:
+- "+" button to add a new line (appears at the bottom)
+- "−" button on each line to remove that line
+- Removing the last extra line (down to 1 remaining line) exits split mode and returns to normal single-entry mode
+- When adding a line with no prior edits, time is divided equally among all lines
+- When adding a line after edits, new line gets minimum duration (1 minute), borrowed from last line
+- Removing a line redistributes its duration to the previous line (or next line if removing first line)
+- Add/remove operations maintain time consistency
+
+### FR4: Equal Time Distribution (Default) & Time Precision
+
+**Description**: When first entering split mode or adding lines without edits, time is distributed equally. Time precision is handled intelligently to balance accuracy with usability.
+
+**Acceptance Criteria - Equal Distribution**:
+- Initially splitting shows 2 lines with equal time distribution (±1 minute for odd durations)
+- Adding a 3rd line redistributes time equally among 3 lines
+- Equal distribution only applies when user hasn't manually edited any durations yet
+- After first manual edit, equal distribution no longer applies to new lines
+
+**Acceptance Criteria - Time Precision**:
+- **Internal precision**: Keep second precision for all timestamps and durations internally
+- **First activity start time**: Display with second precision (HH:MM:SS format), matches AFK period start exactly
+- **Additional activity start times**: Round to nearest minute by default (HH:MM format), but allow user to edit seconds if desired
+- **Duration fields**: Display and accept input in minutes only (integer values)
+- **Rounding tolerance**: Up to ±30 seconds of rounding on first and last activities is acceptable and hidden from user
+- **Total duration**: Internal calculations maintain second precision to match original AFK period duration exactly
+- User can optionally click on start time fields to edit seconds if needed (progressive disclosure)
+
+### FR5: Automatic Time Adjustment
+
+**Description**: Editing any time field automatically adjusts related fields to maintain consistency.
+
+**Acceptance Criteria**:
+- Total duration always equals the original AFK period duration
+- When editing a line's duration:
+  - All subsequent lines' start times shift accordingly
+  - If the duration increase would exceed available time, it's capped at maximum
+  - The last line's duration adjusts to maintain total consistency
+- When editing a line's start time (not first line):
+  - Previous line's duration adjusts to reach the new start time
+  - All subsequent lines shift their start times accordingly
+- All changes update in real-time as user types
+- Invalid states (negative durations, gaps, overlaps) are prevented
+
+### FR6: Validation Rules
+
+**Description**: Ensure data integrity and prevent invalid states. Note that the split feature is specifically for dividing a single AFK period into sequential non-overlapping activities. While overlapping activities are normal in ActivityWatch generally, the split feature models TimeWarrior-style sequential tracking where activities don't overlap.
+
+**Acceptance Criteria**:
+- No gaps between activities (end time of activity N = start time of activity N+1)
+- No overlaps between activities (this is specific to the split feature's sequential model)
+- All durations must be at least 1 minute
+- Total duration must equal original AFK period duration (within 1 second tolerance for rounding)
+- Start time of first activity = AFK period start time
+- End time of last activity = AFK period end time
+- Empty description fields trigger a warning but allow submission
+- Only numeric input accepted for duration fields
+
+### FR7: Data Submission & Error Handling
+
+**Description**: Submit split activities as separate events to ActivityWatch with robust error handling.
+
+**Acceptance Criteria**:
+- Clicking "OK" in split mode posts N separate events (one per activity line)
+- Each event has:
+  - `timestamp`: The activity's start time
+  - `duration`: The activity's duration in seconds
+  - `data.message`: The activity description
+- Events are posted to the same `aw-watcher-ask-away_{hostname}` bucket
+- **Error handling** (fixes current bug where posting failures cause data loss):
+  - Only mark events as "seen" (add to recent_events) AFTER successful posting
+  - If posting fails, queue the events for retry
+  - Display notification to user about queued events
+  - Retry queued events on next iteration
+  - Log posting failures for debugging
+- Clicking "Cancel" discards all changes (same as current behavior)
+
+### FR8: Testing Mode
+
+**Description**: Enable testing without actual AFK periods.
+
+**Acceptance Criteria**:
+- New command-line flag: `--test-dialog`
+- When `--test-dialog` is used:
+  - Shows dialog immediately without waiting for AFK event
+  - Uses test data: Start time = now - 30 minutes, Duration = 30 minutes
+  - Optionally accepts parameters: `--test-dialog-duration MINUTES`
+- When `--testing` flag is set (existing flag):
+  - Posts to test server (localhost:5666) if running
+  - Discards data silently if test server not running
+  - Logs whether data was posted or discarded
+- Regular `--testing` flag behavior preserved for existing tests
+
+### FR9: UI/UX Requirements
+
+**Description**: Maintain consistency with existing dialog design and usability.
+
+**Acceptance Criteria**:
+- Split mode dialog maintains the same styling as current dialog
+- Dialog resizes appropriately when entering/exiting split mode
+- Smooth transition animation preferred (but not required)
+- Keyboard shortcuts:
+  - `Tab`: Move to next field
+  - `Shift+Tab`: Move to previous field
+  - `Ctrl+Enter`: Submit (same as clicking OK)
+  - `Escape`: Cancel (existing behavior)
+  - `Ctrl+Plus` or `Ctrl+=`: Add line
+  - `Ctrl+Minus`: Remove current line (if more than 2 remain)
+- Clear visual indication of which fields are editable vs read-only
+- Duration fields support both typing and scroll wheel (increment/decrement by 1 minute)
+
+### FR10: Backward Compatibility
+
+**Description**: Existing functionality must not be affected.
+
+**Acceptance Criteria**:
+- Users can continue using the dialog without split mode (default behavior)
+- Single-line mode works exactly as before
+- Command-line arguments remain compatible
+- Existing tests continue to pass
+- Configuration file format unchanged
+
+## Non-Functional Requirements
+
+### NFR1: Performance
+
+- Dialog must remain responsive when handling up to 20 activity lines
+- Time recalculations must appear instantaneous (<100ms)
+- No memory leaks from adding/removing lines repeatedly
+
+### NFR2: Code Quality
+
+- Unit test coverage: >90% for split feature code
+- Integration tests for end-to-end split workflow
+- Type hints for all new functions (Python 3.11+ annotations)
+- Documentation strings for all public methods
+- Code follows existing project style (ruff + black formatting)
+
+### NFR3: User Experience
+
+- Clear error messages for validation failures
+- Helpful tooltips on UI elements explaining behavior
+- Consistent with existing dialog aesthetics
+- No modal dialogs blocking user input (use inline validation)
+
+### NFR4: Maintainability
+
+- Split functionality isolated in dedicated module/class where feasible
+- Minimal changes to existing core logic
+- Clear separation between UI and business logic
+- Comprehensive inline comments for complex time calculations
+
+## Technical Design Notes
+
+### Recommended Architecture
+
+1. **New Module**: `src/aw_watcher_ask_away/split_dialog.py`
+   - `SplitActivityDialog` class extending `AWAskAwayDialog`
+   - `ActivityLine` dataclass representing a single activity
+   - `TimeCalculator` utility class for consistency enforcement
+
+2. **Modified Files**:
+   - `__main__.py`: Add `--test-dialog` flag, handle split event posting
+   - `core.py`: Add method to post multiple events atomically
+   - `dialog.py`: Add split button to main dialog
+
+3. **New Test File**: `tests/test_split.py`
+   - Test time calculations
+   - Test add/remove lines
+   - Test validation rules
+   - Test event posting
+   - Test equal distribution logic
+
+### Data Structures
+
+```python
+@dataclass
+class ActivityLine:
+    """Represents a single activity in a split AFK period."""
+    description: str
+    start_time: datetime
+    duration_minutes: int
+
+    @property
+    def end_time(self) -> datetime:
+        return self.start_time + timedelta(minutes=self.duration_minutes)
+
+@dataclass
+class SplitActivityData:
+    """Container for all activity lines in a split period."""
+    original_start: datetime
+    original_duration_seconds: float
+    activities: list[ActivityLine]
+
+    def validate(self) -> list[str]:
+        """Return list of validation errors, empty if valid."""
+        ...
+
+    def is_valid(self) -> bool:
+        """Check if all activities form a valid, consistent timeline."""
+        ...
+```
+
+### Time Calculation Algorithm
+
+When user edits duration of line N:
+1. Calculate delta: `new_duration - old_duration`
+2. If delta > 0 (increasing):
+   - Check if remaining time available in last line >= delta
+   - If yes: subtract delta from last line's duration
+   - If no: cap the new duration at maximum available
+3. If delta < 0 (decreasing):
+   - Add abs(delta) to last line's duration
+4. Recalculate start times for lines N+1 through end
+
+When user edits start time of line N (N > 1):
+1. Calculate delta: `new_start - old_start`
+2. Adjust line N-1's duration by delta
+3. Validate that line N-1's duration >= 1 minute
+4. Recalculate start times for lines N+1 through end
+
+## Testing Strategy
+
+### Unit Tests
+- `test_activity_line_dataclass()`: Test dataclass properties
+- `test_time_calculator_increase_duration()`: Test duration increase logic
+- `test_time_calculator_decrease_duration()`: Test duration decrease logic
+- `test_time_calculator_change_start_time()`: Test start time adjustment
+- `test_equal_distribution()`: Test initial equal time split
+- `test_add_line_no_edits()`: Test adding line with equal distribution
+- `test_add_line_after_edits()`: Test adding line after manual edits
+- `test_remove_line()`: Test removing a line
+- `test_validation_no_gaps()`: Test gap detection
+- `test_validation_no_overlaps()`: Test overlap detection
+- `test_validation_min_duration()`: Test minimum duration enforcement
+- `test_validation_total_duration()`: Test total duration consistency
+
+### Integration Tests
+- `test_split_dialog_creates_multiple_events()`: Test end-to-end workflow
+- `test_split_dialog_cancel_no_events()`: Test cancel behavior
+- `test_split_with_testing_flag()`: Test with --testing mode
+
+### Manual Testing Checklist
+- [ ] Test with very short AFK period (2 minutes)
+- [ ] Test with very long AFK period (2 hours)
+- [ ] Test with odd-duration periods (e.g., 37 minutes 35 seconds)
+- [ ] Test rapid add/remove operations
+- [ ] Test all keyboard shortcuts
+- [ ] Test tab order through fields
+- [ ] Test with empty descriptions
+- [ ] Test `--test-dialog` flag with various durations
+- [ ] Test on different platforms (Linux primary, optional: Windows/macOS)
+- [ ] Test with actual ActivityWatch server running
+- [ ] Test with `--testing` flag and test server
+
+## Implementation Phases
+
+### Phase 1: Core Data Structures & Logic
+- Create `ActivityLine` and `SplitActivityData` dataclasses
+- Implement `TimeCalculator` class
+- Write unit tests for time calculations
+- **Deliverable**: Fully tested time calculation logic
+
+### Phase 2: UI Components
+- Create `SplitActivityDialog` class
+- Implement activity line widgets
+- Add split button to main dialog
+- Implement add/remove line buttons
+- **Deliverable**: Functional UI (without event posting)
+
+### Phase 3: Integration
+- Add `--test-dialog` CLI flag
+- Implement multi-event posting in `core.py`
+- Connect split dialog to event posting
+- Update main loop to handle split mode
+- **Deliverable**: End-to-end working feature
+
+### Phase 4: Testing & Polish
+- Write integration tests
+- Add tooltips and help text
+- Implement keyboard shortcuts
+- Performance testing with 20 lines
+- Manual QA testing
+- **Deliverable**: Production-ready feature
+
+## Design Decisions (Resolved)
+
+1. **Q**: Should we persist the "split" state if user clicks Split, then Cancel, then gets prompted again for the same event?
+   **A**: No. Clicking Cancel discards all data and the user will be prompted again (current behavior). The cancel functionality needs more thought in general, so minimum effort should be spent on this for now.
+
+2. **Q**: Should there be a "Split" option directly on the first dialog, or only appear after clicking a button?
+   **A**: Yes, the "Split" button should be directly visible on the first dialog (not hidden in a menu).
+
+3. **Q**: If posting events fails partway through (e.g., 2 of 5 events posted), what's the recovery strategy?
+   **A**: Queue failed postings for retry and inform the user that some events haven't been posted yet. This addresses a current bug where posting failures cause data loss.
+
+4. **Q**: Should abbreviation expansion work in split mode?
+   **A**: Yes, for consistency with the main dialog (though some users may handle this in aw-export-timewarrior instead).
+
+5. **Q**: Should we store split configuration (number of lines, time distribution) for future use?
+   **A**: Out of scope for v1. May be a future improvement.
+
+## Success Criteria
+
+The feature is considered complete when:
+- [ ] All functional requirements implemented
+- [ ] All unit tests pass with >90% coverage
+- [ ] Integration tests pass
+- [ ] Manual testing checklist completed
+- [ ] Documentation updated (README.md)
+- [ ] User acceptance testing passed
+- [ ] GitHub issue closed
+- [ ] Pull request merged
+
+## References
+
+- Project Repository: https://github.com/Jeremiah-England/aw-watcher-ask-away
+- ActivityWatch API Docs: https://docs.activitywatch.net/
+- Related Issue: [TBD - will be created]

--- a/misc/aw-watcher-ask-away.service
+++ b/misc/aw-watcher-ask-away.service
@@ -1,0 +1,50 @@
+########################################
+# aw-watcher-ask-away.service         #
+########################################
+#
+# This service file provides an alternative way to run aw-watcher-ask-away
+# without using aw-qt. The recommended approach is to use aw-qt, which manages
+# both the server and watchers automatically.
+#
+# This watcher shows GUI dialogs when you return from AFK, so it needs access
+# to your display server.
+#
+# Prerequisites:
+# - aw-server must be installed and running
+# - aw-watcher-afk must be running (ask-away monitors AFK events)
+# - This watcher must be installed (pip install aw-watcher-ask-away)
+#
+# Installation for X11 users:
+# 1. Copy service file: cp misc/aw-watcher-ask-away.service ~/.config/systemd/user/
+# 2. Reload systemd: systemctl --user daemon-reload
+# 3. Enable the service: systemctl --user enable aw-watcher-ask-away.service
+# 4. Start the service: systemctl --user start aw-watcher-ask-away.service
+#
+# Additional setup for Wayland users:
+# - Add to your compositor startup script (e.g., ~/.config/sway/config):
+#   exec systemctl --user import-environment WAYLAND_DISPLAY
+# - This ensures the service can access your Wayland display
+#
+# The watcher will automatically retry connection to aw-server if it's not ready yet.
+#
+
+[Unit]
+Description=ActivityWatch AFK Questionnaire Watcher
+Documentation=https://github.com/Jeremiah-England/aw-watcher-ask-away
+After=aw-server.service
+# Ensure we run within a graphical session
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=aw-watcher-ask-away
+Restart=on-failure
+RestartSec=10
+Environment=PYTHONUNBUFFERED=1
+# Set DISPLAY for X11 users (Wayland users should import WAYLAND_DISPLAY)
+Environment="DISPLAY=:0"
+# Note: For Wayland, also run: systemctl --user import-environment WAYLAND_DISPLAY
+# Add this command to your compositor/session startup script
+
+[Install]
+WantedBy=default.target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
-dependencies = ["aw-client", "appdirs"]
+dependencies = ["aw-client", "aw-core", "appdirs"]
 
 [project.scripts]
 aw-watcher-ask-away = "aw_watcher_ask_away.__main__:main"

--- a/src/aw_watcher_ask_away/__main__.py
+++ b/src/aw_watcher_ask_away/__main__.py
@@ -28,7 +28,7 @@ def prompt(event: aw_core.Event, recent_events: Iterable[aw_core.Event]):
     prompt = f"What were you doing from {start_time_str} - {end_time_str} ({event.duration.seconds / 60:.1f} minutes)?"
     title = "AFK Checkin"
 
-    return aw_dialog.ask_string(title, prompt, [event.data[DATA_KEY] for event in recent_events])
+    return aw_dialog.ask_string(title, prompt, [event.data.get(DATA_KEY, '') for event in recent_events])
 
 
 def get_state_retries(client: ActivityWatchClient, enable_lid_events: bool = True):

--- a/src/aw_watcher_ask_away/__main__.py
+++ b/src/aw_watcher_ask_away/__main__.py
@@ -10,6 +10,7 @@ from aw_core.log import setup_logging
 from requests.exceptions import ConnectionError
 
 import aw_watcher_ask_away.dialog as aw_dialog
+from aw_watcher_ask_away.config import load_config
 from aw_watcher_ask_away.core import (
     DATA_KEY,
     LOCAL_TIMEZONE,
@@ -47,15 +48,27 @@ def get_state_retries(client: ActivityWatchClient):
 
 
 def main():
+    # Load config from file (falls back to defaults if file doesn't exist)
+    config = load_config()
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--depth", type=float, default=10, help="The number of minutes to look into the past for events."
+        "--depth",
+        type=float,
+        default=config.get("depth", 10),
+        help="The number of minutes to look into the past for events. (default: from config or 10)",
     )
     parser.add_argument(
-        "--frequency", type=float, default=5, help="The number of seconds to wait before checking for AFK events again."
+        "--frequency",
+        type=float,
+        default=config.get("frequency", 5),
+        help="The number of seconds to wait before checking for AFK events again. (default: from config or 5)",
     )
     parser.add_argument(
-        "--length", type=float, default=5, help="The number of minutes you need to be away before reporting on it."
+        "--length",
+        type=float,
+        default=config.get("length", 5),
+        help="The number of minutes you need to be away before reporting on it. (default: from config or 5)",
     )
     parser.add_argument("--testing", action="store_true", help="Run in testing mode.")
     parser.add_argument("--verbose", action="store_true", help="I want to see EVERYTHING!")

--- a/src/aw_watcher_ask_away/__main__.py
+++ b/src/aw_watcher_ask_away/__main__.py
@@ -31,7 +31,7 @@ def prompt(event: aw_core.Event, recent_events: Iterable[aw_core.Event]):
     return aw_dialog.ask_string(title, prompt, [event.data[DATA_KEY] for event in recent_events])
 
 
-def get_state_retries(client: ActivityWatchClient):
+def get_state_retries(client: ActivityWatchClient, enable_lid_events: bool = True):
     """When the computer is starting up sometimes the aw-server is not ready for requests yet.
 
     So we sit and retry for a while before giving up.
@@ -40,7 +40,7 @@ def get_state_retries(client: ActivityWatchClient):
         try:
             # This works because the constructor of AWAskAwayState tries to get bucket names.
             # If it didn't we'd need to do something else here.
-            return AWAskAwayClient(client)
+            return AWAskAwayClient(client, enable_lid_events=enable_lid_events)
         except ConnectionError:
             logger.exception("Cannot connect to client.")
             time.sleep(10)  # 10 * 10 = wait for 100s before giving up.
@@ -88,7 +88,7 @@ def main():
             client_name=WATCHER_NAME, testing=args.testing
         )
         with client:
-            state = get_state_retries(client)
+            state = get_state_retries(client, enable_lid_events=config.get("enable_lid_events", True))
             logger.info("Successfully connected to the server.")
 
             while True:

--- a/src/aw_watcher_ask_away/__main__.py
+++ b/src/aw_watcher_ask_away/__main__.py
@@ -13,18 +13,18 @@ import aw_watcher_ask_away.dialog as aw_dialog
 from aw_watcher_ask_away.config import load_config
 from aw_watcher_ask_away.core import (
     DATA_KEY,
-    LOCAL_TIMEZONE,
     WATCHER_NAME,
     AWAskAwayClient,
     AWWatcherAskAwayError,
     logger,
 )
+from aw_watcher_ask_away.utils import format_time_local
 
 
 def prompt(event: aw_core.Event, recent_events: Iterable[aw_core.Event]):
     # TODO: Allow for customizing the prompt from the prompt interface.
-    start_time_str = event.timestamp.astimezone(LOCAL_TIMEZONE).strftime("%I:%M")
-    end_time_str = (event.timestamp + event.duration).astimezone(LOCAL_TIMEZONE).strftime("%I:%M")
+    start_time_str = format_time_local(event.timestamp)
+    end_time_str = format_time_local(event.timestamp + event.duration)
     prompt_text = f"What were you doing from {start_time_str} - {end_time_str} ({event.duration.seconds / 60:.1f} minutes)?"
     title = "AFK Checkin"
 
@@ -110,10 +110,8 @@ def main():
         test_start = datetime.now(UTC) - timedelta(minutes=args.test_dialog_duration)
         test_duration_seconds = args.test_dialog_duration * 60
 
-        start_time_str = test_start.astimezone(LOCAL_TIMEZONE).strftime("%I:%M")
-        end_time_str = (test_start + timedelta(seconds=test_duration_seconds)).astimezone(
-            LOCAL_TIMEZONE
-        ).strftime("%I:%M")
+        start_time_str = format_time_local(test_start)
+        end_time_str = format_time_local(test_start + timedelta(seconds=test_duration_seconds))
         test_prompt = f"What were you doing from {start_time_str} - {end_time_str} ({args.test_dialog_duration:.1f} minutes)?"
         title = "AFK Checkin (TEST MODE)"
 

--- a/src/aw_watcher_ask_away/config.py
+++ b/src/aw_watcher_ask_away/config.py
@@ -11,6 +11,12 @@ frequency = 5.0
 
 # Number of minutes you need to be away before reporting on it
 length = 5.0
+
+# Enable integration with aw-watcher-lid for lid/suspend events
+# OPTIONAL: Requires aw-watcher-lid to be installed and running
+# See: https://github.com/tobixen/aw-watcher-lid
+# When enabled, you'll be prompted about lid closures in addition to regular AFK
+enable_lid_events = true
 """.strip()
 
 

--- a/src/aw_watcher_ask_away/config.py
+++ b/src/aw_watcher_ask_away/config.py
@@ -1,0 +1,22 @@
+"""Configuration management for aw-watcher-ask-away."""
+
+from aw_core.config import load_config_toml
+
+DEFAULT_CONFIG = """
+# Number of minutes to look into the past for events
+depth = 10.0
+
+# Number of seconds to wait before checking for AFK events again
+frequency = 5.0
+
+# Number of minutes you need to be away before reporting on it
+length = 5.0
+""".strip()
+
+
+def load_config() -> dict:
+    """Load configuration using ActivityWatch standard approach.
+
+    Config location: ~/.config/activitywatch/aw-watcher-ask-away/aw-watcher-ask-away.toml
+    """
+    return load_config_toml("aw-watcher-ask-away", DEFAULT_CONFIG)

--- a/src/aw_watcher_ask_away/core.py
+++ b/src/aw_watcher_ask_away/core.py
@@ -136,10 +136,11 @@ class AWAskAwayClient:
                 except HTTPError:
                     logger.warning("Failed to get lid events, continuing with AFK events only")
 
-            # Merge events from both sources
-            all_events = afk_events + lid_events
+            # Merge and sort events from both sources by timestamp (most recent first)
+            all_events = aw_transform.sort_by_timestamp(afk_events + lid_events)
 
             # Check if currently AFK (from either source)
+            # Most recent event is first after sorting
             if all_events and is_afk(all_events[0]):
                 # Currently AFK, wait to bring up the prompt
                 return

--- a/src/aw_watcher_ask_away/core.py
+++ b/src/aw_watcher_ask_away/core.py
@@ -136,14 +136,18 @@ class AWAskAwayClient:
                 except HTTPError:
                     logger.warning("Failed to get lid events, continuing with AFK events only")
 
-            # Merge and sort events from both sources by timestamp (most recent first)
+            # Merge and sort events from both sources by timestamp
+            # Note: sort_by_timestamp() sorts in ASCENDING order (oldest first)
             all_events = aw_transform.sort_by_timestamp(afk_events + lid_events)
 
             # Check if currently AFK (from either source)
-            # Most recent event is first after sorting
-            if all_events and is_afk(all_events[0]):
-                # Currently AFK, wait to bring up the prompt
-                return
+            # Most recent event is LAST after sorting (ascending order)
+            if all_events:
+                most_recent = all_events[-1]  # Last element is most recent
+                currently_afk = is_afk(most_recent)
+                if currently_afk:
+                    # Currently AFK, wait to bring up the prompt
+                    return
 
             yield from self.state.get_unseen_afk_events(all_events, seconds, durration_thresh)
         except HTTPError:

--- a/src/aw_watcher_ask_away/core.py
+++ b/src/aw_watcher_ask_away/core.py
@@ -13,6 +13,8 @@ import aw_transform
 from aw_client.client import ActivityWatchClient
 from requests.exceptions import HTTPError
 
+from aw_watcher_ask_away.utils import LOCAL_TIMEZONE, format_time_local
+
 # Import ActivityLine for split mode support
 try:
     from aw_watcher_ask_away.split_dialog import ActivityLine
@@ -21,7 +23,6 @@ except ImportError:
     ActivityLine = None
 
 WATCHER_NAME = "aw-watcher-ask-away"
-LOCAL_TIMEZONE = datetime.datetime.now().astimezone().tzinfo
 DATA_KEY = "message"
 """What field in the event data to store the user's message in."""
 

--- a/src/aw_watcher_ask_away/dialog.py
+++ b/src/aw_watcher_ask_away/dialog.py
@@ -214,8 +214,10 @@ class AWAskAwayDialog(simpledialog.Dialog):
         # Text editing shortcuts
         # TODO: Wrap the Entry widget so we can reuse these in other dialogs.
         self.bind("<Control-BackSpace>", self.remove_word)
-        self.bind("<Control-u>", self.remove_to_start)
         self.bind("<Control-w>", self.remove_word)
+
+        # Quick dismiss as UNKNOWN (Ctrl-U)
+        self.bind("<Control-u>", self.submit_unknown)
 
         # Open web interface shortcut
         self.bind("<Control-o>", self.open_web_interface)
@@ -328,7 +330,17 @@ class AWAskAwayDialog(simpledialog.Dialog):
 
     # If you want to retrieve the entered text when the dialog closes:
     def apply(self):
-        self.result = self.entry.get().strip()
+        text = self.entry.get().strip()
+        if not text:
+            # Don't accept blank entries - show error and keep dialog open
+            messagebox.showerror("Empty Entry", "Please enter a description of what you were doing, or click 'Unknown' to mark as unknown.")
+            return  # Don't close dialog
+        self.result = text
+
+    def submit_unknown(self, event=None):  # noqa: ARG002
+        """Quick dismiss as UNKNOWN."""
+        self.result = "UNKNOWN"
+        self.cancel()
 
     def open_config(self, event=None):  # noqa: ARG002
         ConfigDialog(self)
@@ -355,13 +367,17 @@ class AWAskAwayDialog(simpledialog.Dialog):
     def buttonbox(self):
         """The buttons at the bottom of the dialog.
 
-        This is overridden to add Split and Settings buttons.
+        This is overridden to add Split, Unknown, and Settings buttons.
         """
         box = ttk.Frame(self)
 
         w = ttk.Button(box, text="OK", width=10, command=self.ok, default=tk.ACTIVE)
         w.pack(side=tk.LEFT, padx=5, pady=5)
         w = ttk.Button(box, text="Cancel", width=10, command=self.cancel_with_snooze)
+        w.pack(side=tk.LEFT, padx=5, pady=5)
+
+        # Unknown button - quick dismiss for forgotten activities (Ctrl-U)
+        w = ttk.Button(box, text="Unknown", width=10, command=self.submit_unknown)
         w.pack(side=tk.LEFT, padx=5, pady=5)
 
         # Split button (only show if afk_start and afk_duration_seconds are provided)

--- a/src/aw_watcher_ask_away/split_dialog.py
+++ b/src/aw_watcher_ask_away/split_dialog.py
@@ -1,0 +1,1008 @@
+"""Split AFK period dialog - allows dividing a single AFK period into multiple activities.
+
+This module provides data structures and logic for splitting an AFK period into
+multiple sequential activities with different descriptions and time allocations.
+"""
+
+import logging
+import tkinter as tk
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from tkinter import simpledialog, ttk
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ActivityLine:
+    """Represents a single activity in a split AFK period.
+
+    Each activity has a description, start time, and duration. Activities are
+    sequential (no gaps or overlaps) within the parent AFK period.
+
+    Attributes:
+        description: User-provided description of the activity
+        start_time: When the activity started (datetime with timezone)
+        duration_minutes: How long the activity lasted (in minutes, integer)
+        duration_seconds: Additional seconds beyond duration_minutes (for internal precision)
+    """
+
+    description: str
+    start_time: datetime
+    duration_minutes: int
+    duration_seconds: int = 0  # Internal precision for sub-minute accuracy
+
+    @property
+    def end_time(self) -> datetime:
+        """Calculate the end time of this activity."""
+        return self.start_time + timedelta(minutes=self.duration_minutes, seconds=self.duration_seconds)
+
+    @property
+    def total_duration_seconds(self) -> float:
+        """Get total duration in seconds (including sub-minute precision)."""
+        return self.duration_minutes * 60 + self.duration_seconds
+
+    def __post_init__(self) -> None:
+        """Validate the activity line after initialization."""
+        if self.duration_minutes < 0:
+            raise ValueError(f"Duration cannot be negative: {self.duration_minutes}")
+        if self.duration_seconds < 0 or self.duration_seconds >= 60:
+            raise ValueError(f"Duration seconds must be in [0, 60): {self.duration_seconds}")
+
+
+@dataclass
+class SplitActivityData:
+    """Container for all activity lines in a split AFK period.
+
+    Maintains consistency constraints:
+    - No gaps between activities
+    - No overlaps between activities
+    - Total duration equals original AFK period duration
+    - First activity starts at AFK period start
+    - Last activity ends at AFK period end
+
+    Attributes:
+        original_start: Start time of the original AFK period
+        original_duration_seconds: Total duration of the original AFK period in seconds
+        activities: List of ActivityLine objects (must be chronologically ordered)
+    """
+
+    original_start: datetime
+    original_duration_seconds: float
+    activities: list[ActivityLine] = field(default_factory=list)
+
+    @property
+    def original_end(self) -> datetime:
+        """Calculate the end time of the original AFK period."""
+        return self.original_start + timedelta(seconds=self.original_duration_seconds)
+
+    def validate(self) -> list[str]:
+        """Validate the split activity data and return list of errors.
+
+        Returns:
+            List of error messages (empty if valid)
+        """
+        errors = []
+
+        if not self.activities:
+            errors.append("No activities defined")
+            return errors
+
+        # Check first activity starts at AFK period start
+        if self.activities[0].start_time != self.original_start:
+            errors.append(
+                f"First activity must start at AFK period start "
+                f"({self.original_start.isoformat()}), "
+                f"got {self.activities[0].start_time.isoformat()}"
+            )
+
+        # Check for gaps and overlaps between consecutive activities
+        for i in range(len(self.activities) - 1):
+            current = self.activities[i]
+            next_activity = self.activities[i + 1]
+
+            # Check minimum duration
+            if current.duration_minutes < 1:
+                errors.append(f"Activity {i+1} duration must be at least 1 minute")
+
+            # Check no gap between activities (allow ±1 second tolerance for rounding)
+            if current.end_time != next_activity.start_time:
+                gap_seconds = (next_activity.start_time - current.end_time).total_seconds()
+                if abs(gap_seconds) > 1.0:
+                    if gap_seconds > 0:
+                        errors.append(
+                            f"Gap detected between activity {i+1} and {i+2}: {gap_seconds:.1f} seconds"
+                        )
+                    else:
+                        errors.append(
+                            f"Overlap detected between activity {i+1} and {i+2}: {-gap_seconds:.1f} seconds"
+                        )
+
+        # Check last activity minimum duration
+        if self.activities and self.activities[-1].duration_minutes < 1:
+            errors.append(f"Activity {len(self.activities)} duration must be at least 1 minute")
+
+        # Check last activity ends at AFK period end (with 30 second tolerance for rounding)
+        if self.activities:
+            last_end = self.activities[-1].end_time
+            expected_end = self.original_end
+            diff_seconds = abs((last_end - expected_end).total_seconds())
+            if diff_seconds > 30.0:
+                errors.append(
+                    f"Last activity must end at AFK period end "
+                    f"({expected_end.isoformat()}), "
+                    f"got {last_end.isoformat()} (diff: {diff_seconds:.1f}s)"
+                )
+
+        # Check total duration matches original (with 30 second tolerance for rounding)
+        if self.activities:
+            total_seconds = sum(a.total_duration_seconds for a in self.activities)
+            diff = abs(total_seconds - self.original_duration_seconds)
+            if diff > 30.0:
+                errors.append(
+                    f"Total duration mismatch: expected {self.original_duration_seconds:.1f}s, "
+                    f"got {total_seconds:.1f}s (diff: {diff:.1f}s)"
+                )
+
+        return errors
+
+    def is_valid(self) -> bool:
+        """Check if all activities form a valid, consistent timeline.
+
+        Returns:
+            True if valid, False otherwise
+        """
+        return len(self.validate()) == 0
+
+
+class TimeCalculator:
+    """Utility class for time calculations and consistency enforcement.
+
+    Handles automatic adjustment of activity times to maintain consistency
+    when user edits duration or start time fields.
+    """
+
+    @staticmethod
+    def split_equal(
+        start: datetime,
+        duration_seconds: float,
+        num_activities: int,
+        descriptions: Optional[list[str]] = None
+    ) -> list[ActivityLine]:
+        """Split an AFK period into equal-duration activities.
+
+        Args:
+            start: Start time of the AFK period
+            duration_seconds: Total duration in seconds
+            num_activities: Number of activities to create
+            descriptions: Optional list of descriptions (default: empty strings)
+
+        Returns:
+            List of ActivityLine objects with equal durations
+        """
+        if num_activities < 1:
+            raise ValueError("Must create at least 1 activity")
+
+        if descriptions is None:
+            descriptions = [""] * num_activities
+        elif len(descriptions) != num_activities:
+            raise ValueError(f"Expected {num_activities} descriptions, got {len(descriptions)}")
+
+        # Calculate duration per activity
+        seconds_per_activity = duration_seconds / num_activities
+        minutes_per_activity = int(seconds_per_activity // 60)
+
+        activities = []
+        current_start = start
+
+        for i in range(num_activities):
+            # For the last activity, calculate duration to exactly reach the end
+            if i == num_activities - 1:
+                remaining_seconds = duration_seconds - sum(a.total_duration_seconds for a in activities)
+                duration_mins = int(remaining_seconds // 60)
+                duration_secs = int(remaining_seconds % 60)
+            else:
+                duration_mins = minutes_per_activity
+                duration_secs = int(seconds_per_activity % 60)
+
+            activity = ActivityLine(
+                description=descriptions[i],
+                start_time=current_start,
+                duration_minutes=duration_mins,
+                duration_seconds=duration_secs
+            )
+            activities.append(activity)
+            current_start = activity.end_time
+
+        return activities
+
+    @staticmethod
+    def adjust_duration(
+        activities: list[ActivityLine],
+        index: int,
+        new_duration_minutes: int,
+        original_end: Optional[datetime] = None
+    ) -> list[ActivityLine]:
+        """Adjust the duration of an activity and update subsequent activities.
+
+        When a user changes the duration of an activity:
+        - All subsequent activities' start times shift accordingly
+        - If original_end is provided, the last activity's duration adjusts to maintain total consistency
+
+        Args:
+            activities: Current list of activities
+            index: Index of the activity to adjust
+            new_duration_minutes: New duration in minutes
+            original_end: Optional end time of original AFK period (for adjusting last activity)
+
+        Returns:
+            New list of activities with adjustments applied
+        """
+        if not activities or index < 0 or index >= len(activities):
+            raise ValueError(f"Invalid index: {index}")
+
+        if new_duration_minutes < 1:
+            raise ValueError("Duration must be at least 1 minute")
+
+        # Special case: if changing the LAST activity and original_end is provided,
+        # adjust the PREVIOUS activity instead to maintain total duration
+        if index == len(activities) - 1 and original_end is not None and len(activities) > 1:
+            # The last activity must end at original_end, so calculate its new start time
+            new_last_duration = timedelta(minutes=new_duration_minutes, seconds=activities[index].duration_seconds)
+            new_last_start = original_end - new_last_duration
+
+            # The previous activity must end at the new last activity's start
+            prev_activity = activities[index - 1]
+            prev_new_duration_seconds = (new_last_start - prev_activity.start_time).total_seconds()
+
+            if prev_new_duration_seconds < 60:
+                raise ValueError("Adjustment would make previous activity less than 1 minute")
+
+            prev_new_duration_minutes = int(prev_new_duration_seconds // 60)
+
+            # Recursively adjust the previous activity
+            # This will handle cascading changes if there are more activities
+            return TimeCalculator.adjust_duration(
+                activities,
+                index=index - 1,
+                new_duration_minutes=prev_new_duration_minutes,
+                original_end=original_end
+            )
+
+        # Create a copy to avoid mutating the original
+        new_activities = []
+        for i, activity in enumerate(activities):
+            if i < index:
+                # Activities before the changed one remain the same
+                new_activities.append(ActivityLine(
+                    description=activity.description,
+                    start_time=activity.start_time,
+                    duration_minutes=activity.duration_minutes,
+                    duration_seconds=activity.duration_seconds
+                ))
+            elif i == index:
+                # This is the activity being changed
+                new_activities.append(ActivityLine(
+                    description=activity.description,
+                    start_time=activity.start_time,
+                    duration_minutes=new_duration_minutes,
+                    duration_seconds=activity.duration_seconds
+                ))
+            elif i == len(activities) - 1 and original_end is not None:
+                # Last activity: adjust duration to reach original_end
+                prev_end = new_activities[-1].end_time
+                remaining_seconds = (original_end - prev_end).total_seconds()
+                if remaining_seconds < 60:
+                    raise ValueError("Adjusted duration would make last activity less than 1 minute")
+
+                new_activities.append(ActivityLine(
+                    description=activity.description,
+                    start_time=prev_end,
+                    duration_minutes=int(remaining_seconds // 60),
+                    duration_seconds=int(remaining_seconds % 60)
+                ))
+            else:
+                # Subsequent activities: shift start time based on previous activity's end
+                prev_end = new_activities[-1].end_time
+                new_activities.append(ActivityLine(
+                    description=activity.description,
+                    start_time=prev_end,
+                    duration_minutes=activity.duration_minutes,
+                    duration_seconds=activity.duration_seconds
+                ))
+
+        return new_activities
+
+    @staticmethod
+    def adjust_start_time(
+        activities: list[ActivityLine],
+        index: int,
+        new_start: datetime,
+        original_end: Optional[datetime] = None
+    ) -> list[ActivityLine]:
+        """Adjust the start time of an activity and update related activities.
+
+        When a user changes the start time of an activity (not the first one):
+        - Previous activity's duration adjusts to reach the new start time
+        - All subsequent activities shift their start times accordingly
+        - If original_end is provided, the last activity's duration adjusts to maintain total consistency
+
+        Args:
+            activities: Current list of activities
+            index: Index of the activity to adjust (must be > 0)
+            new_start: New start time
+            original_end: Optional end time of original AFK period (for adjusting last activity)
+
+        Returns:
+            New list of activities with adjustments applied
+        """
+        if not activities or index <= 0 or index >= len(activities):
+            raise ValueError(f"Invalid index: {index} (must be > 0)")
+
+        # Create a copy to avoid mutating the original
+        new_activities = []
+        for i, activity in enumerate(activities):
+            if i < index - 1:
+                # Activities before the previous one remain the same
+                new_activities.append(ActivityLine(
+                    description=activity.description,
+                    start_time=activity.start_time,
+                    duration_minutes=activity.duration_minutes,
+                    duration_seconds=activity.duration_seconds
+                ))
+            elif i == index - 1:
+                # Previous activity: adjust duration to reach new start time
+                new_duration_seconds = (new_start - activity.start_time).total_seconds()
+                if new_duration_seconds < 60:
+                    raise ValueError("Adjusted duration would be less than 1 minute")
+
+                new_activities.append(ActivityLine(
+                    description=activity.description,
+                    start_time=activity.start_time,
+                    duration_minutes=int(new_duration_seconds // 60),
+                    duration_seconds=int(new_duration_seconds % 60)
+                ))
+            elif i == index:
+                # This is the activity being changed
+                if i == len(activities) - 1 and original_end is not None:
+                    # This is also the last activity: adjust duration to reach original_end
+                    remaining_seconds = (original_end - new_start).total_seconds()
+                    if remaining_seconds < 60:
+                        raise ValueError("Adjusted duration would make last activity less than 1 minute")
+
+                    new_activities.append(ActivityLine(
+                        description=activity.description,
+                        start_time=new_start,
+                        duration_minutes=int(remaining_seconds // 60),
+                        duration_seconds=int(remaining_seconds % 60)
+                    ))
+                else:
+                    # Not the last activity: keep original duration
+                    new_activities.append(ActivityLine(
+                        description=activity.description,
+                        start_time=new_start,
+                        duration_minutes=activity.duration_minutes,
+                        duration_seconds=activity.duration_seconds
+                    ))
+            elif i == len(activities) - 1 and original_end is not None:
+                # Last activity: adjust duration to reach original_end
+                prev_end = new_activities[-1].end_time
+                remaining_seconds = (original_end - prev_end).total_seconds()
+                if remaining_seconds < 60:
+                    raise ValueError("Adjusted duration would make last activity less than 1 minute")
+
+                new_activities.append(ActivityLine(
+                    description=activity.description,
+                    start_time=prev_end,
+                    duration_minutes=int(remaining_seconds // 60),
+                    duration_seconds=int(remaining_seconds % 60)
+                ))
+            else:
+                # Subsequent activities: shift start time based on previous activity's end
+                prev_end = new_activities[-1].end_time
+                new_activities.append(ActivityLine(
+                    description=activity.description,
+                    start_time=prev_end,
+                    duration_minutes=activity.duration_minutes,
+                    duration_seconds=activity.duration_seconds
+                ))
+
+        return new_activities
+
+    @staticmethod
+    def add_activity(
+        activities: list[ActivityLine],
+        original_end: datetime,
+        equal_distribution: bool = False,
+        original_start: Optional[datetime] = None,
+        original_duration_seconds: Optional[float] = None
+    ) -> list[ActivityLine]:
+        """Add a new activity line.
+
+        Args:
+            activities: Current list of activities
+            original_end: End time of the original AFK period
+            equal_distribution: If True, redistribute time equally among all activities
+            original_start: Required if equal_distribution is True
+            original_duration_seconds: Required if equal_distribution is True
+
+        Returns:
+            New list of activities with the added line
+        """
+        if not activities:
+            raise ValueError("Cannot add activity to empty list")
+
+        if equal_distribution:
+            if original_start is None or original_duration_seconds is None:
+                raise ValueError("original_start and original_duration_seconds required for equal distribution")
+
+            # Redistribute time equally
+            descriptions = [a.description for a in activities] + [""]
+            return TimeCalculator.split_equal(
+                original_start,
+                original_duration_seconds,
+                len(activities) + 1,
+                descriptions
+            )
+        else:
+            # Borrow 1 minute from last activity
+            last = activities[-1]
+            if last.duration_minutes <= 1:
+                raise ValueError("Last activity must have more than 1 minute to add a new line")
+
+            # Create new list with adjusted last activity
+            new_activities = activities[:-1] + [
+                ActivityLine(
+                    description=last.description,
+                    start_time=last.start_time,
+                    duration_minutes=last.duration_minutes - 1,
+                    duration_seconds=last.duration_seconds
+                )
+            ]
+
+            # Add new activity with 1 minute duration
+            new_start = new_activities[-1].end_time
+            remaining_seconds = (original_end - new_start).total_seconds()
+
+            new_activities.append(ActivityLine(
+                description="",
+                start_time=new_start,
+                duration_minutes=int(remaining_seconds // 60),
+                duration_seconds=int(remaining_seconds % 60)
+            ))
+
+            return new_activities
+
+    @staticmethod
+    def remove_activity(activities: list[ActivityLine], index: int) -> list[ActivityLine]:
+        """Remove an activity line and redistribute its duration.
+
+        The removed activity's duration is added to the previous activity
+        (or next activity if removing the first one).
+
+        Args:
+            activities: Current list of activities
+            index: Index of the activity to remove
+
+        Returns:
+            New list of activities with the removed line
+        """
+        if not activities or index < 0 or index >= len(activities):
+            raise ValueError(f"Invalid index: {index}")
+
+        if len(activities) == 1:
+            # Removing the last activity - return empty list (exits split mode)
+            return []
+
+        removed = activities[index]
+        new_activities = []
+
+        if index == 0:
+            # Removing first activity: add its duration to the next one
+            for i, activity in enumerate(activities):
+                if i == 0:
+                    continue  # Skip the removed activity
+                elif i == 1:
+                    # Next activity gets the removed activity's duration
+                    total_seconds = removed.total_duration_seconds + activity.total_duration_seconds
+                    new_activities.append(ActivityLine(
+                        description=activity.description,
+                        start_time=removed.start_time,  # Use removed activity's start time
+                        duration_minutes=int(total_seconds // 60),
+                        duration_seconds=int(total_seconds % 60)
+                    ))
+                else:
+                    # Subsequent activities shift start times
+                    prev_end = new_activities[-1].end_time
+                    new_activities.append(ActivityLine(
+                        description=activity.description,
+                        start_time=prev_end,
+                        duration_minutes=activity.duration_minutes,
+                        duration_seconds=activity.duration_seconds
+                    ))
+        else:
+            # Removing non-first activity: add its duration to the previous one
+            for i, activity in enumerate(activities):
+                if i == index:
+                    continue  # Skip the removed activity
+                elif i == index - 1:
+                    # Previous activity gets the removed activity's duration
+                    total_seconds = activity.total_duration_seconds + removed.total_duration_seconds
+                    new_activities.append(ActivityLine(
+                        description=activity.description,
+                        start_time=activity.start_time,
+                        duration_minutes=int(total_seconds // 60),
+                        duration_seconds=int(total_seconds % 60)
+                    ))
+                elif i > index:
+                    # Subsequent activities shift start times
+                    prev_end = new_activities[-1].end_time
+                    new_activities.append(ActivityLine(
+                        description=activity.description,
+                        start_time=prev_end,
+                        duration_minutes=activity.duration_minutes,
+                        duration_seconds=activity.duration_seconds
+                    ))
+                else:
+                    # Activities before removed one remain the same
+                    new_activities.append(ActivityLine(
+                        description=activity.description,
+                        start_time=activity.start_time,
+                        duration_minutes=activity.duration_minutes,
+                        duration_seconds=activity.duration_seconds
+                    ))
+
+        return new_activities
+
+
+# ============================================================================
+# UI Components
+# ============================================================================
+
+class ActivityLineWidget:
+    """Widget for displaying and editing a single activity line.
+
+    Shows description field, start time, duration in minutes, and remove button.
+    Does not use a Frame - widgets are gridded directly into parent.
+    """
+
+    def __init__(self, parent, row: int, index: int, activity: ActivityLine,
+                 is_first: bool, on_change_callback, on_remove_callback):
+        """Initialize activity line widget.
+
+        Args:
+            parent: Parent frame to grid widgets into
+            row: Grid row number for this activity
+            index: Activity index in the list
+            activity: ActivityLine data
+            is_first: Whether this is the first activity (start time read-only)
+            on_change_callback: Callback when any field changes
+            on_remove_callback: Callback when remove button clicked
+        """
+        self.parent = parent
+        self.row = row
+        self.index = index
+        self.is_first = is_first
+        self.on_change = on_change_callback
+        self.on_remove = on_remove_callback
+
+        logger.debug(f"Creating widget for activity {index}: desc='{activity.description}', "
+                    f"start={activity.start_time.strftime('%H:%M:%S')}, "
+                    f"duration={activity.duration_minutes}m")
+
+        # Description field (editable)
+        self.desc_var = tk.StringVar(master=parent, value=activity.description)
+        self.desc_var.trace_add("write", lambda *args: self._on_desc_change())
+        self.desc_entry = ttk.Entry(parent, textvariable=self.desc_var, width=25)
+        self.desc_entry.grid(row=row, column=0, padx=5, pady=2, sticky=tk.W+tk.E)
+
+        # Start time field (read-only for first, editable for others)
+        start_str = activity.start_time.strftime("%H:%M:%S") if is_first else activity.start_time.strftime("%H:%M")
+        self.start_var = tk.StringVar(master=parent, value=start_str)
+        if not is_first:
+            self.start_var.trace_add("write", lambda *args: self._on_start_change())
+        self.start_entry = ttk.Entry(parent, textvariable=self.start_var, width=10,
+                               state='readonly' if is_first else 'normal',
+                               takefocus=0 if is_first else 1)
+        self.start_entry.grid(row=row, column=1, padx=5, pady=2)
+
+        # Duration field (minutes only, editable)
+        self.duration_var = tk.IntVar(master=parent, value=activity.duration_minutes)
+        self.duration_var.trace_add("write", lambda *args: self._on_duration_change())
+        self.duration_spinbox = ttk.Spinbox(parent, from_=1, to=9999, width=6,
+                                      textvariable=self.duration_var)
+        self.duration_spinbox.grid(row=row, column=2, padx=5, pady=2)
+
+        # Remove button
+        self.remove_btn = ttk.Button(parent, text="−", width=3,
+                               command=lambda: self.on_remove(index))
+        self.remove_btn.grid(row=row, column=3, padx=5, pady=2)
+
+    def _on_desc_change(self):
+        """Handle description change."""
+        desc = self.desc_var.get()
+        logger.debug(f"Activity {self.index} description changed to: '{desc}'")
+        # Notify parent about description change
+        self.on_change(field='description', value=desc)
+
+    def _on_start_change(self):
+        """Handle start time change."""
+        start = self.start_var.get()
+        logger.debug(f"Activity {self.index} start time changed to: '{start}'")
+        # Notify parent about start time change
+        self.on_change(field='start_time', value=start)
+
+    def _on_duration_change(self):
+        """Handle duration change."""
+        try:
+            duration = self.duration_var.get()
+            logger.debug(f"Activity {self.index} duration changed to: {duration}")
+            # Notify parent about duration change
+            self.on_change(field='duration', value=duration)
+        except tk.TclError as e:
+            logger.warning(f"Invalid duration value for activity {self.index}: {e}")
+
+    def destroy(self):
+        """Destroy all widgets in this line."""
+        self.desc_entry.destroy()
+        self.start_entry.destroy()
+        self.duration_spinbox.destroy()
+        self.remove_btn.destroy()
+
+    def get_description(self) -> str:
+        """Get the current description value."""
+        return self.desc_var.get()
+
+    def get_start_time_str(self) -> str:
+        """Get the current start time string."""
+        return self.start_var.get()
+
+    def get_duration_minutes(self) -> int:
+        """Get the current duration in minutes."""
+        try:
+            return self.duration_var.get()
+        except tk.TclError:
+            return 1  # Default to 1 if invalid
+
+    def update_from_activity(self, activity: ActivityLine, is_first: bool):
+        """Update widget values from an ActivityLine without triggering callbacks."""
+        # Temporarily remove traces to avoid triggering callbacks
+        desc_trace_id = self.desc_var.trace_info()[0][1] if self.desc_var.trace_info() else None
+        duration_trace_id = self.duration_var.trace_info()[0][1] if self.duration_var.trace_info() else None
+        start_trace_id = self.start_var.trace_info()[0][1] if self.start_var.trace_info() and not is_first else None
+
+        if desc_trace_id:
+            self.desc_var.trace_remove("write", desc_trace_id)
+        if duration_trace_id:
+            self.duration_var.trace_remove("write", duration_trace_id)
+        if start_trace_id:
+            self.start_var.trace_remove("write", start_trace_id)
+
+        # Update values
+        self.desc_var.set(activity.description)
+        start_str = activity.start_time.strftime("%H:%M:%S") if is_first else activity.start_time.strftime("%H:%M")
+        self.start_var.set(start_str)
+        self.duration_var.set(activity.duration_minutes)
+
+        # Re-add traces
+        self.desc_var.trace_add("write", lambda *args: self._on_desc_change())
+        self.duration_var.trace_add("write", lambda *args: self._on_duration_change())
+        if not is_first:
+            self.start_var.trace_add("write", lambda *args: self._on_start_change())
+
+
+class SplitActivityDialog(simpledialog.Dialog):
+    """Dialog for splitting an AFK period into multiple activities.
+    
+    Allows users to:
+    - Split a single AFK period into multiple sequential activities
+    - Add/remove activity lines
+    - Edit descriptions, start times, and durations
+    - Automatic time consistency enforcement
+    """
+    
+    def __init__(self, parent, title: str, prompt: str,
+                 afk_start: datetime, afk_duration_seconds: float,
+                 history: list[str]):
+        """Initialize the split activity dialog.
+
+        Args:
+            parent: Parent tkinter widget
+            title: Dialog window title
+            prompt: Prompt text to display
+            afk_start: Start time of the AFK period
+            afk_duration_seconds: Duration of the AFK period in seconds
+            history: List of previous descriptions for abbreviation expansion
+        """
+        self.prompt = prompt
+        self.afk_start = afk_start
+        self.afk_duration_seconds = afk_duration_seconds
+        self.afk_end = afk_start + timedelta(seconds=afk_duration_seconds)
+        self.history = history
+
+        # Initialize with 2 equal activities
+        self.activities = TimeCalculator.split_equal(
+            afk_start, afk_duration_seconds, 2
+        )
+        self.equal_distribution_mode = True  # Track if user has edited durations
+
+        self.activity_widgets = []
+        self.result = None  # Will be set to list of ActivityLine on OK, None on Cancel
+        self.return_to_single_mode = False  # Flag to indicate returning to single-entry mode
+        self.single_mode_description = ""  # Description to use when returning to single mode
+
+        super().__init__(parent, title)
+    
+    def body(self, master):
+        """Create the dialog body with activity line widgets."""
+        self.master_frame = ttk.Frame(master)
+        self.master_frame.grid(sticky=tk.W+tk.E+tk.N+tk.S)
+
+        # Prompt label
+        prompt_label = ttk.Label(self.master_frame, text=self.prompt, justify=tk.LEFT)
+        prompt_label.grid(row=0, column=0, columnspan=5, padx=5, pady=5, sticky=tk.W)
+
+        # Header row
+        ttk.Label(self.master_frame, text="Description", font=('TkDefaultFont', 9, 'bold')).grid(
+            row=1, column=0, padx=5, pady=2, sticky=tk.W)
+        ttk.Label(self.master_frame, text="Start", font=('TkDefaultFont', 9, 'bold')).grid(
+            row=1, column=1, padx=5, pady=2, sticky=tk.W)
+        ttk.Label(self.master_frame, text="Mins", font=('TkDefaultFont', 9, 'bold')).grid(
+            row=1, column=2, padx=5, pady=2, sticky=tk.W)
+
+        # Activities will be drawn starting at row 2
+        self.first_activity_row = 2
+
+        # Draw initial activity widgets
+        self.redraw_activities()
+
+        # Configure column resizing
+        self.master_frame.columnconfigure(0, weight=1)
+
+        # Focus on first description field
+        if self.activity_widgets:
+            return self.activity_widgets[0].desc_entry
+        return None
+    
+    def redraw_activities(self):
+        """Redraw all activity line widgets."""
+        # Clear existing widgets
+        for widget in self.activity_widgets:
+            widget.destroy()
+        self.activity_widgets = []
+
+        # Destroy add button if it exists
+        if hasattr(self, 'add_btn'):
+            self.add_btn.destroy()
+
+        # Create new widgets for each activity
+        for i, activity in enumerate(self.activities):
+            row = self.first_activity_row + i
+            widget = ActivityLineWidget(
+                parent=self.master_frame,
+                row=row,
+                index=i,
+                activity=activity,
+                is_first=(i == 0),
+                on_change_callback=lambda field, value, idx=i: self.on_activity_changed(idx, field, value),
+                on_remove_callback=self.remove_activity_line
+            )
+            self.activity_widgets.append(widget)
+
+        # Add button below all activities
+        add_row = self.first_activity_row + len(self.activities)
+        self.add_btn = ttk.Button(self.master_frame, text="+", command=self.add_activity_line)
+        self.add_btn.grid(row=add_row, column=0, padx=5, pady=5, sticky=tk.W)
+    
+    def on_activity_changed(self, changed_index: int, field: str, value):
+        """Handle changes to any activity field.
+
+        Args:
+            changed_index: Index of the activity that was changed
+            field: Which field was changed ('description', 'start_time', or 'duration')
+            value: The new value
+        """
+        # Mark that user has made edits (disable equal distribution mode)
+        self.equal_distribution_mode = False
+
+        try:
+            if field == 'description':
+                # Just update the description in the activity
+                activity = self.activities[changed_index]
+                self.activities[changed_index] = ActivityLine(
+                    description=value,
+                    start_time=activity.start_time,
+                    duration_minutes=activity.duration_minutes,
+                    duration_seconds=activity.duration_seconds
+                )
+                logger.info(f"Activity {changed_index} description updated to: '{value}'")
+
+            elif field == 'duration':
+                # Use TimeCalculator to adjust the duration
+                logger.info(f"Activity {changed_index} duration changed to {value} minutes")
+                self.activities = TimeCalculator.adjust_duration(
+                    self.activities,
+                    index=changed_index,
+                    new_duration_minutes=value,
+                    original_end=self.afk_end
+                )
+
+                # Log all activity durations after recalculation
+                for i, activity in enumerate(self.activities):
+                    logger.info(
+                        f"  Activity {i}: '{activity.description}' - "
+                        f"{activity.start_time.strftime('%H:%M:%S')} - "
+                        f"{activity.duration_minutes}m {activity.duration_seconds}s"
+                    )
+
+                # Update all widgets to reflect changes (without triggering callbacks)
+                for i, (widget, activity) in enumerate(zip(self.activity_widgets, self.activities)):
+                    widget.update_from_activity(activity, i == 0)
+
+            elif field == 'start_time':
+                # Parse start time string (HH:MM format) and adjust
+                if changed_index == 0:
+                    # First activity start time is not editable
+                    logger.warning(f"Cannot edit start time of first activity")
+                    return
+
+                try:
+                    # Parse HH:MM format
+                    parts = value.split(':')
+                    if len(parts) != 2:
+                        logger.warning(f"Invalid start time format: {value}")
+                        return
+
+                    hours = int(parts[0])
+                    minutes = int(parts[1])
+
+                    if hours < 0 or hours > 23 or minutes < 0 or minutes > 59:
+                        logger.warning(f"Invalid time values: {hours}:{minutes}")
+                        return
+
+                    # Create new datetime with same date but updated time
+                    old_start = self.activities[changed_index].start_time
+                    new_start = old_start.replace(hour=hours, minute=minutes, second=0, microsecond=0)
+
+                    logger.info(f"Activity {changed_index} start time changed to {new_start.strftime('%H:%M')}")
+
+                    # Use TimeCalculator to adjust the start time
+                    self.activities = TimeCalculator.adjust_start_time(
+                        self.activities,
+                        index=changed_index,
+                        new_start=new_start,
+                        original_end=self.afk_end
+                    )
+
+                    # Log all activities after recalculation
+                    for i, activity in enumerate(self.activities):
+                        logger.info(
+                            f"  Activity {i}: '{activity.description}' - "
+                            f"{activity.start_time.strftime('%H:%M:%S')} - "
+                            f"{activity.duration_minutes}m {activity.duration_seconds}s"
+                        )
+
+                    # Update all widgets to reflect changes
+                    for i, (widget, activity) in enumerate(zip(self.activity_widgets, self.activities)):
+                        widget.update_from_activity(activity, i == 0)
+
+                except (ValueError, IndexError) as e:
+                    logger.warning(f"Error parsing start time '{value}': {e}")
+
+        except (ValueError, tk.TclError) as e:
+            logger.warning(f"Error updating activity {changed_index}: {e}")
+            pass
+    
+    def add_activity_line(self):
+        """Add a new activity line."""
+        try:
+            self.activities = TimeCalculator.add_activity(
+                self.activities,
+                self.afk_end,
+                equal_distribution=self.equal_distribution_mode,
+                original_start=self.afk_start if self.equal_distribution_mode else None,
+                original_duration_seconds=self.afk_duration_seconds if self.equal_distribution_mode else None
+            )
+            self.redraw_activities()
+        except ValueError as e:
+            # Show error message
+            tk.messagebox.showerror("Cannot Add Activity", str(e))
+    
+    def remove_activity_line(self, index: int):
+        """Remove an activity line."""
+        self.activities = TimeCalculator.remove_activity(self.activities, index)
+
+        # If only 1 activity left, return to single-entry mode (exit split mode)
+        if len(self.activities) <= 1:
+            logger.info("Only 1 activity remaining, returning to single-entry mode")
+            self.return_to_single_mode = True
+            if self.activities:
+                self.single_mode_description = self.activities[0].description
+            else:
+                self.single_mode_description = ""
+            # Close the dialog
+            self.destroy()
+            return
+
+        self.redraw_activities()
+    
+    def buttonbox(self):
+        """Create OK and Cancel buttons."""
+        box = ttk.Frame(self)
+        
+        ok_btn = ttk.Button(box, text="OK", width=10, command=self.ok, default=tk.ACTIVE)
+        ok_btn.pack(side=tk.LEFT, padx=5, pady=5)
+        
+        cancel_btn = ttk.Button(box, text="Cancel", width=10, command=self.cancel)
+        cancel_btn.pack(side=tk.LEFT, padx=5, pady=5)
+        
+        self.bind("<Return>", self.ok)
+        self.bind("<Escape>", self.cancel)
+        
+        # Keyboard shortcuts for add/remove
+        self.bind("<Control-plus>", lambda e: self.add_activity_line())
+        self.bind("<Control-equal>", lambda e: self.add_activity_line())  # + without shift
+        
+        box.pack()
+    
+    def validate(self) -> bool:
+        """Validate the split activity data before accepting."""
+        # Create SplitActivityData and validate
+        data = SplitActivityData(
+            original_start=self.afk_start,
+            original_duration_seconds=self.afk_duration_seconds,
+            activities=self.activities
+        )
+
+        errors = data.validate()
+        if errors:
+            # Log validation errors
+            logger.error("Validation failed:")
+            for err in errors:
+                logger.error(f"  • {err}")
+
+            error_msg = "Validation errors:\n\n" + "\n".join(f"• {err}" for err in errors)
+            tk.messagebox.showerror("Invalid Split", error_msg)
+            return False
+
+        return True
+    
+    def apply(self):
+        """Called when OK is clicked and validation passes."""
+        self.result = self.activities
+
+
+def ask_split_activities(title: str, prompt: str, afk_start: datetime,
+                         afk_duration_seconds: float, history: list[str],
+                         parent=None) -> Optional[list[ActivityLine]] | str:
+    """Show split activity dialog and return list of activities, description, or None.
+
+    Args:
+        title: Dialog window title
+        prompt: Prompt text to display
+        afk_start: Start time of the AFK period
+        afk_duration_seconds: Duration of the AFK period in seconds
+        history: List of previous descriptions for abbreviation expansion
+        parent: Parent tkinter widget (optional)
+
+    Returns:
+        - List of ActivityLine objects if OK clicked in split mode
+        - String description if user removed activities down to 1 (return to single mode)
+        - None if cancelled
+    """
+    if parent is None:
+        # Create hidden root if needed
+        import tkinter as tk
+        root = tk.Tk()
+        root.withdraw()
+        parent = root
+
+    dialog = SplitActivityDialog(parent, title, prompt, afk_start,
+                                 afk_duration_seconds, history)
+
+    # Check if user removed activities down to 1 (return to single mode)
+    if dialog.return_to_single_mode:
+        return dialog.single_mode_description
+
+    return dialog.result

--- a/src/aw_watcher_ask_away/split_dialog.py
+++ b/src/aw_watcher_ask_away/split_dialog.py
@@ -11,6 +11,8 @@ from datetime import datetime, timedelta
 from tkinter import simpledialog, ttk
 from typing import Optional
 
+from aw_watcher_ask_away.utils import format_time_local
+
 logger = logging.getLogger(__name__)
 
 
@@ -598,7 +600,8 @@ class ActivityLineWidget:
         self.desc_entry.grid(row=row, column=0, padx=5, pady=2, sticky=tk.W+tk.E)
 
         # Start time field (read-only for first, editable for others)
-        start_str = activity.start_time.strftime("%H:%M:%S") if is_first else activity.start_time.strftime("%H:%M")
+        # Use locale-aware formatting with timezone conversion
+        start_str = format_time_local(activity.start_time, include_seconds=is_first)
         self.start_var = tk.StringVar(master=parent, value=start_str)
         if not is_first:
             self.start_var.trace_add("write", lambda *args: self._on_start_change())
@@ -681,7 +684,7 @@ class ActivityLineWidget:
 
         # Update values
         self.desc_var.set(activity.description)
-        start_str = activity.start_time.strftime("%H:%M:%S") if is_first else activity.start_time.strftime("%H:%M")
+        start_str = format_time_local(activity.start_time, include_seconds=is_first)
         self.start_var.set(start_str)
         self.duration_var.set(activity.duration_minutes)
 

--- a/src/aw_watcher_ask_away/utils.py
+++ b/src/aw_watcher_ask_away/utils.py
@@ -1,0 +1,45 @@
+"""Utility functions for aw-watcher-ask-away."""
+
+import datetime
+import locale
+
+LOCAL_TIMEZONE = datetime.datetime.now().astimezone().tzinfo
+
+
+def format_time_local(dt: datetime.datetime, include_seconds: bool = False) -> str:
+    """Format a datetime as local time using locale-appropriate format.
+
+    Uses 24-hour clock unless the locale prefers 12-hour format.
+    Always converts to local timezone first.
+
+    Args:
+        dt: Datetime to format (can be any timezone, will be converted to local)
+        include_seconds: Whether to include seconds in the output
+
+    Returns:
+        Formatted time string (e.g., "14:30" or "2:30 PM" depending on locale)
+    """
+    # Convert to local timezone
+    local_dt = dt.astimezone(LOCAL_TIMEZONE)
+
+    # Check locale preference for time format
+    # %X gives the locale's preferred time representation
+    # We check if it contains AM/PM indicators to detect 12-hour preference
+    try:
+        locale_time_format = locale.nl_langinfo(locale.T_FMT)
+        use_12_hour = '%p' in locale_time_format or '%P' in locale_time_format or \
+                      '%I' in locale_time_format or '%r' in locale_time_format
+    except (AttributeError, locale.Error):
+        # Fallback: use 24-hour format if we can't determine locale
+        use_12_hour = False
+
+    if use_12_hour:
+        if include_seconds:
+            return local_dt.strftime("%I:%M:%S %p").lstrip("0")
+        else:
+            return local_dt.strftime("%I:%M %p").lstrip("0")
+    else:
+        if include_seconds:
+            return local_dt.strftime("%H:%M:%S")
+        else:
+            return local_dt.strftime("%H:%M")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,61 @@
+"""Tests for configuration loading."""
+
+from unittest.mock import patch
+
+from aw_watcher_ask_away.config import DEFAULT_CONFIG, load_config
+
+
+def test_default_config_has_expected_keys() -> None:
+    """Test that DEFAULT_CONFIG contains all expected configuration keys."""
+    # Parse the default config string to check it's valid TOML
+    import tomllib
+
+    config = tomllib.loads(DEFAULT_CONFIG)
+
+    assert "depth" in config
+    assert "frequency" in config
+    assert "length" in config
+
+
+def test_default_config_values() -> None:
+    """Test that DEFAULT_CONFIG has expected default values."""
+    import tomllib
+
+    config = tomllib.loads(DEFAULT_CONFIG)
+
+    assert config["depth"] == 10.0
+    assert config["frequency"] == 5.0
+    assert config["length"] == 5.0
+
+
+def test_load_config_returns_defaults_when_no_file() -> None:
+    """Test that load_config returns defaults when config file doesn't exist."""
+    # Mock aw_core.config.load_config_toml to return parsed defaults
+    with patch("aw_watcher_ask_away.config.load_config_toml") as mock_load:
+        import tomllib
+
+        mock_load.return_value = tomllib.loads(DEFAULT_CONFIG)
+
+        config = load_config()
+
+        # Verify load_config_toml was called with correct arguments
+        mock_load.assert_called_once_with("aw-watcher-ask-away", DEFAULT_CONFIG)
+
+        # Verify returned config has expected values
+        assert config["depth"] == 10.0
+        assert config["frequency"] == 5.0
+        assert config["length"] == 5.0
+
+
+def test_load_config_returns_custom_values() -> None:
+    """Test that load_config returns custom values when config file exists."""
+    custom_config = {"depth": 15.0, "frequency": 10.0, "length": 3.0}
+
+    with patch("aw_watcher_ask_away.config.load_config_toml") as mock_load:
+        mock_load.return_value = custom_config
+
+        config = load_config()
+
+        assert config["depth"] == 15.0
+        assert config["frequency"] == 10.0
+        assert config["length"] == 3.0

--- a/tests/test_lid_integration.py
+++ b/tests/test_lid_integration.py
@@ -1,0 +1,56 @@
+"""Tests for lid watcher integration."""
+
+import aw_core
+import pytest
+
+from aw_watcher_ask_away.core import AWWatcherAskAwayError, find_lid_bucket, is_afk
+
+
+def test_find_lid_bucket_found() -> None:
+    """Test finding lid bucket when it exists."""
+    buckets = {
+        "aw-watcher-afk_hostname": {},
+        "aw-watcher-lid_hostname": {},
+    }
+
+    lid_bucket = find_lid_bucket(buckets)
+    assert lid_bucket == "aw-watcher-lid_hostname"
+
+
+def test_find_lid_bucket_not_found() -> None:
+    """Test finding lid bucket when it doesn't exist."""
+    buckets = {
+        "aw-watcher-afk_hostname": {},
+    }
+
+    lid_bucket = find_lid_bucket(buckets)
+    assert lid_bucket is None
+
+
+def test_find_lid_bucket_multiple() -> None:
+    """Test error when multiple lid buckets found."""
+    buckets = {
+        "aw-watcher-lid_hostname1": {},
+        "aw-watcher-lid_hostname2": {},
+    }
+
+    with pytest.raises(AWWatcherAskAwayError, match="too many lid buckets"):
+        find_lid_bucket(buckets)
+
+
+def test_is_afk_regular() -> None:
+    """Test is_afk with regular AFK event."""
+    event = aw_core.Event(data={"status": "afk"})
+    assert is_afk(event) is True
+
+
+def test_is_afk_system() -> None:
+    """Test is_afk with system-afk event from lid watcher."""
+    event = aw_core.Event(data={"status": "system-afk"})
+    assert is_afk(event) is True
+
+
+def test_is_afk_not_afk() -> None:
+    """Test is_afk with not-afk event."""
+    event = aw_core.Event(data={"status": "not-afk"})
+    assert is_afk(event) is False

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,0 +1,618 @@
+"""Unit tests for split AFK period functionality."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aw_watcher_ask_away.split_dialog import (
+    ActivityLine,
+    SplitActivityData,
+    TimeCalculator,
+)
+
+
+class TestActivityLine:
+    """Test ActivityLine dataclass."""
+
+    def test_activity_line_creation(self) -> None:
+        """Test creating an ActivityLine."""
+        start = datetime(2025, 1, 15, 14, 30, 0, tzinfo=UTC)
+        activity = ActivityLine(
+            description="lunch",
+            start_time=start,
+            duration_minutes=20,
+            duration_seconds=30
+        )
+
+        assert activity.description == "lunch"
+        assert activity.start_time == start
+        assert activity.duration_minutes == 20
+        assert activity.duration_seconds == 30
+
+    def test_end_time_calculation(self) -> None:
+        """Test end_time property calculates correctly."""
+        start = datetime(2025, 1, 15, 14, 30, 0, tzinfo=UTC)
+        activity = ActivityLine(
+            description="meeting",
+            start_time=start,
+            duration_minutes=45,
+            duration_seconds=15
+        )
+
+        expected_end = start + timedelta(minutes=45, seconds=15)
+        assert activity.end_time == expected_end
+
+    def test_total_duration_seconds(self) -> None:
+        """Test total_duration_seconds property."""
+        activity = ActivityLine(
+            description="test",
+            start_time=datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC),
+            duration_minutes=5,
+            duration_seconds=30
+        )
+
+        assert activity.total_duration_seconds == 5 * 60 + 30
+
+    def test_negative_duration_minutes_rejected(self) -> None:
+        """Test that negative duration_minutes raises ValueError."""
+        with pytest.raises(ValueError, match="Duration cannot be negative"):
+            ActivityLine(
+                description="test",
+                start_time=datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC),
+                duration_minutes=-5,
+                duration_seconds=0
+            )
+
+    def test_invalid_duration_seconds_rejected(self) -> None:
+        """Test that invalid duration_seconds raises ValueError."""
+        with pytest.raises(ValueError, match="Duration seconds must be in"):
+            ActivityLine(
+                description="test",
+                start_time=datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC),
+                duration_minutes=5,
+                duration_seconds=65
+            )
+
+
+class TestSplitActivityData:
+    """Test SplitActivityData dataclass and validation."""
+
+    def test_valid_split_data(self) -> None:
+        """Test validation passes for valid data."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("lunch", start, 20, 0),
+            ActivityLine("phone", start + timedelta(minutes=20), 10, 0)
+        ]
+
+        data = SplitActivityData(
+            original_start=start,
+            original_duration_seconds=30 * 60,
+            activities=activities
+        )
+
+        assert data.is_valid()
+        assert len(data.validate()) == 0
+
+    def test_first_activity_wrong_start(self) -> None:
+        """Test validation fails if first activity doesn't start at AFK period start."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        wrong_start = start + timedelta(minutes=5)
+        activities = [
+            ActivityLine("test", wrong_start, 30, 0)
+        ]
+
+        data = SplitActivityData(
+            original_start=start,
+            original_duration_seconds=30 * 60,
+            activities=activities
+        )
+
+        assert not data.is_valid()
+        errors = data.validate()
+        assert any("First activity must start" in e for e in errors)
+
+    def test_gap_detected(self) -> None:
+        """Test validation detects gaps between activities."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("lunch", start, 20, 0),
+            # Gap of 5 minutes
+            ActivityLine("phone", start + timedelta(minutes=25), 5, 0)
+        ]
+
+        data = SplitActivityData(
+            original_start=start,
+            original_duration_seconds=30 * 60,
+            activities=activities
+        )
+
+        assert not data.is_valid()
+        errors = data.validate()
+        assert any("Gap detected" in e for e in errors)
+
+    def test_overlap_detected(self) -> None:
+        """Test validation detects overlaps between activities."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("lunch", start, 20, 0),
+            # Overlap: starts 5 minutes early
+            ActivityLine("phone", start + timedelta(minutes=15), 10, 0)
+        ]
+
+        data = SplitActivityData(
+            original_start=start,
+            original_duration_seconds=30 * 60,
+            activities=activities
+        )
+
+        assert not data.is_valid()
+        errors = data.validate()
+        assert any("Overlap detected" in e for e in errors)
+
+    def test_minimum_duration_enforced(self) -> None:
+        """Test validation enforces minimum 1 minute duration."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("short", start, 0, 30),  # 30 seconds, too short
+            ActivityLine("rest", start + timedelta(seconds=30), 29, 30)
+        ]
+
+        data = SplitActivityData(
+            original_start=start,
+            original_duration_seconds=30 * 60,
+            activities=activities
+        )
+
+        assert not data.is_valid()
+        errors = data.validate()
+        assert any("duration must be at least 1 minute" in e for e in errors)
+
+    def test_last_activity_wrong_end(self) -> None:
+        """Test validation fails if last activity doesn't end at AFK period end."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("test", start, 20, 0)  # Ends 10 minutes early
+        ]
+
+        data = SplitActivityData(
+            original_start=start,
+            original_duration_seconds=30 * 60,
+            activities=activities
+        )
+
+        assert not data.is_valid()
+        errors = data.validate()
+        assert any("Last activity must end" in e for e in errors)
+
+    def test_total_duration_mismatch(self) -> None:
+        """Test validation fails if total duration doesn't match."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("test1", start, 10, 0),
+            ActivityLine("test2", start + timedelta(minutes=10), 10, 0)
+        ]
+
+        data = SplitActivityData(
+            original_start=start,
+            original_duration_seconds=30 * 60,  # Should be 20 * 60
+            activities=activities
+        )
+
+        assert not data.is_valid()
+        errors = data.validate()
+        assert any("Total duration mismatch" in e for e in errors)
+
+    def test_rounding_tolerance(self) -> None:
+        """Test validation allows 1 second tolerance for rounding."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        # Total: 29 minutes 59 seconds (1 second short, should be tolerated)
+        activities = [
+            ActivityLine("test1", start, 15, 0),
+            ActivityLine("test2", start + timedelta(minutes=15), 14, 59)
+        ]
+
+        data = SplitActivityData(
+            original_start=start,
+            original_duration_seconds=30 * 60,
+            activities=activities
+        )
+
+        assert data.is_valid()
+
+
+class TestTimeCalculatorSplitEqual:
+    """Test TimeCalculator.split_equal() method."""
+
+    def test_split_into_two_equal(self) -> None:
+        """Test splitting into 2 equal activities."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        duration = 30 * 60  # 30 minutes
+
+        activities = TimeCalculator.split_equal(start, duration, 2)
+
+        assert len(activities) == 2
+        assert activities[0].start_time == start
+        assert activities[0].duration_minutes == 15
+        assert activities[1].start_time == start + timedelta(minutes=15)
+        assert activities[1].duration_minutes == 15
+
+    def test_split_into_three_equal(self) -> None:
+        """Test splitting into 3 equal activities."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        duration = 30 * 60  # 30 minutes
+
+        activities = TimeCalculator.split_equal(start, duration, 3)
+
+        assert len(activities) == 3
+        assert all(a.duration_minutes == 10 for a in activities)
+
+    def test_split_odd_duration(self) -> None:
+        """Test splitting odd duration distributes remainder to last activity."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        duration = 37 * 60 + 35  # 37 minutes 35 seconds
+
+        activities = TimeCalculator.split_equal(start, duration, 2)
+
+        assert len(activities) == 2
+        # First: 18 minutes 47 seconds
+        assert activities[0].duration_minutes == 18
+        assert activities[0].duration_seconds == 47
+        # Last gets remainder to exactly match total
+        total_seconds = sum(a.total_duration_seconds for a in activities)
+        assert total_seconds == duration
+
+    def test_split_with_descriptions(self) -> None:
+        """Test splitting with custom descriptions."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        duration = 30 * 60
+        descriptions = ["lunch", "phone call"]
+
+        activities = TimeCalculator.split_equal(start, duration, 2, descriptions)
+
+        assert activities[0].description == "lunch"
+        assert activities[1].description == "phone call"
+
+    def test_split_invalid_num_activities(self) -> None:
+        """Test split with invalid number of activities raises error."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+
+        with pytest.raises(ValueError, match="Must create at least 1 activity"):
+            TimeCalculator.split_equal(start, 1800, 0)
+
+    def test_split_description_count_mismatch(self) -> None:
+        """Test split with wrong number of descriptions raises error."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+
+        with pytest.raises(ValueError, match="Expected 2 descriptions"):
+            TimeCalculator.split_equal(start, 1800, 2, ["only one"])
+
+
+class TestTimeCalculatorAdjustDuration:
+    """Test TimeCalculator.adjust_duration() method."""
+
+    def test_increase_duration(self) -> None:
+        """Test increasing an activity's duration."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("lunch", start, 15, 0),
+            ActivityLine("phone", start + timedelta(minutes=15), 15, 0)
+        ]
+
+        # Increase first activity from 15 to 20 minutes
+        new_activities = TimeCalculator.adjust_duration(activities, 0, 20)
+
+        assert new_activities[0].duration_minutes == 20
+        # Second activity shifts start time
+        assert new_activities[1].start_time == start + timedelta(minutes=20)
+        assert new_activities[1].duration_minutes == 15
+
+    def test_decrease_duration(self) -> None:
+        """Test decreasing an activity's duration."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("lunch", start, 20, 0),
+            ActivityLine("phone", start + timedelta(minutes=20), 10, 0)
+        ]
+
+        # Decrease first activity from 20 to 15 minutes
+        new_activities = TimeCalculator.adjust_duration(activities, 0, 15)
+
+        assert new_activities[0].duration_minutes == 15
+        # Second activity shifts start time earlier
+        assert new_activities[1].start_time == start + timedelta(minutes=15)
+
+    def test_adjust_middle_activity(self) -> None:
+        """Test adjusting a middle activity affects all subsequent ones."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("a", start, 10, 0),
+            ActivityLine("b", start + timedelta(minutes=10), 10, 0),
+            ActivityLine("c", start + timedelta(minutes=20), 10, 0)
+        ]
+
+        # Increase middle activity from 10 to 15 minutes
+        new_activities = TimeCalculator.adjust_duration(activities, 1, 15)
+
+        assert new_activities[0].duration_minutes == 10  # Unchanged
+        assert new_activities[1].duration_minutes == 15  # Changed
+        # Third activity shifts
+        assert new_activities[2].start_time == start + timedelta(minutes=25)
+
+    def test_adjust_minimum_duration(self) -> None:
+        """Test cannot set duration below 1 minute."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [ActivityLine("test", start, 5, 0)]
+
+        with pytest.raises(ValueError, match="Duration must be at least 1 minute"):
+            TimeCalculator.adjust_duration(activities, 0, 0)
+
+    def test_adjust_invalid_index(self) -> None:
+        """Test adjusting with invalid index raises error."""
+        activities = [ActivityLine("test", datetime(2025, 1, 1, 10, 0, 0, tzinfo=UTC), 10, 0)]
+
+        with pytest.raises(ValueError, match="Invalid index"):
+            TimeCalculator.adjust_duration(activities, 5, 10)
+
+
+class TestTimeCalculatorAdjustStartTime:
+    """Test TimeCalculator.adjust_start_time() method."""
+
+    def test_adjust_start_time_second_activity(self) -> None:
+        """Test adjusting start time of second activity."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("lunch", start, 20, 0),
+            ActivityLine("phone", start + timedelta(minutes=20), 10, 0)
+        ]
+
+        # Move second activity to start 5 minutes earlier
+        new_start = start + timedelta(minutes=15)
+        new_activities = TimeCalculator.adjust_start_time(activities, 1, new_start)
+
+        # First activity's duration adjusted to 15 minutes
+        assert new_activities[0].duration_minutes == 15
+        # Second activity starts at new time
+        assert new_activities[1].start_time == new_start
+
+    def test_adjust_middle_activity_start(self) -> None:
+        """Test adjusting middle activity affects previous and subsequent activities."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("a", start, 10, 0),
+            ActivityLine("b", start + timedelta(minutes=10), 10, 0),
+            ActivityLine("c", start + timedelta(minutes=20), 10, 0)
+        ]
+
+        # Move middle activity to start 5 minutes later
+        new_start = start + timedelta(minutes=15)
+        new_activities = TimeCalculator.adjust_start_time(activities, 1, new_start)
+
+        # First activity's duration increased to 15 minutes
+        assert new_activities[0].duration_minutes == 15
+        # Second activity starts at new time
+        assert new_activities[1].start_time == new_start
+        # Third activity shifts
+        assert new_activities[2].start_time == new_start + timedelta(minutes=10)
+
+    def test_cannot_adjust_first_activity(self) -> None:
+        """Test cannot adjust start time of first activity."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [ActivityLine("test", start, 10, 0)]
+
+        with pytest.raises(ValueError, match="Invalid index.*must be > 0"):
+            TimeCalculator.adjust_start_time(activities, 0, start + timedelta(minutes=5))
+
+    def test_adjust_would_make_previous_too_short(self) -> None:
+        """Test error if adjustment would make previous activity < 1 minute."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("a", start, 5, 0),
+            ActivityLine("b", start + timedelta(minutes=5), 5, 0)
+        ]
+
+        # Try to move second activity too early
+        new_start = start + timedelta(seconds=30)  # Only 30 seconds for first activity
+
+        with pytest.raises(ValueError, match="Adjusted duration would be less than 1 minute"):
+            TimeCalculator.adjust_start_time(activities, 1, new_start)
+
+
+class TestTimeCalculatorAddActivity:
+    """Test TimeCalculator.add_activity() method."""
+
+    def test_add_with_equal_distribution(self) -> None:
+        """Test adding activity with equal distribution."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        duration = 30 * 60
+        activities = [
+            ActivityLine("lunch", start, 30, 0)
+        ]
+
+        new_activities = TimeCalculator.add_activity(
+            activities,
+            start + timedelta(seconds=duration),
+            equal_distribution=True,
+            original_start=start,
+            original_duration_seconds=duration
+        )
+
+        # Now 2 activities with 15 minutes each
+        assert len(new_activities) == 2
+        assert new_activities[0].duration_minutes == 15
+        assert new_activities[1].duration_minutes == 15
+        assert new_activities[0].description == "lunch"
+        assert new_activities[1].description == ""
+
+    def test_add_borrowing_from_last(self) -> None:
+        """Test adding activity by borrowing time from last activity."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        duration = 30 * 60
+        activities = [
+            ActivityLine("lunch", start, 15, 0),
+            ActivityLine("phone", start + timedelta(minutes=15), 15, 0)
+        ]
+
+        original_end = start + timedelta(seconds=duration)
+        new_activities = TimeCalculator.add_activity(
+            activities,
+            original_end,
+            equal_distribution=False
+        )
+
+        # Last activity gets remaining time
+        assert len(new_activities) == 3
+        # New activity at the end
+        assert new_activities[2].description == ""
+
+    def test_cannot_add_if_last_too_short(self) -> None:
+        """Test cannot add activity if last one is only 1 minute."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("a", start, 29, 0),
+            ActivityLine("b", start + timedelta(minutes=29), 1, 0)
+        ]
+
+        with pytest.raises(ValueError, match="Last activity must have more than 1 minute"):
+            TimeCalculator.add_activity(
+                activities,
+                start + timedelta(minutes=30),
+                equal_distribution=False
+            )
+
+    def test_add_requires_params_for_equal_distribution(self) -> None:
+        """Test equal distribution requires original_start and original_duration_seconds."""
+        activities = [ActivityLine("test", datetime(2025, 1, 1, 10, 0, 0, tzinfo=UTC), 10, 0)]
+
+        with pytest.raises(ValueError, match="required for equal distribution"):
+            TimeCalculator.add_activity(
+                activities,
+                datetime(2025, 1, 1, 10, 10, 0, tzinfo=UTC),
+                equal_distribution=True
+            )
+
+
+class TestTimeCalculatorRemoveActivity:
+    """Test TimeCalculator.remove_activity() method."""
+
+    def test_remove_first_activity(self) -> None:
+        """Test removing first activity adds its duration to next one."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("lunch", start, 15, 0),
+            ActivityLine("phone", start + timedelta(minutes=15), 15, 0)
+        ]
+
+        new_activities = TimeCalculator.remove_activity(activities, 0)
+
+        assert len(new_activities) == 1
+        # Remaining activity starts at original start and has combined duration
+        assert new_activities[0].start_time == start
+        assert new_activities[0].duration_minutes == 30
+        assert new_activities[0].description == "phone"
+
+    def test_remove_last_activity(self) -> None:
+        """Test removing last activity adds its duration to previous one."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("lunch", start, 15, 0),
+            ActivityLine("phone", start + timedelta(minutes=15), 15, 0)
+        ]
+
+        new_activities = TimeCalculator.remove_activity(activities, 1)
+
+        assert len(new_activities) == 1
+        # Remaining activity has combined duration
+        assert new_activities[0].duration_minutes == 30
+        assert new_activities[0].description == "lunch"
+
+    def test_remove_middle_activity(self) -> None:
+        """Test removing middle activity adds duration to previous one."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        activities = [
+            ActivityLine("a", start, 10, 0),
+            ActivityLine("b", start + timedelta(minutes=10), 10, 0),
+            ActivityLine("c", start + timedelta(minutes=20), 10, 0)
+        ]
+
+        new_activities = TimeCalculator.remove_activity(activities, 1)
+
+        assert len(new_activities) == 2
+        # First activity gets middle activity's duration
+        assert new_activities[0].duration_minutes == 20
+        # Last activity shifts start time
+        assert new_activities[1].start_time == start + timedelta(minutes=20)
+
+    def test_remove_only_activity(self) -> None:
+        """Test removing the only activity returns empty list."""
+        activities = [ActivityLine("only", datetime(2025, 1, 1, 10, 0, 0, tzinfo=UTC), 10, 0)]
+
+        new_activities = TimeCalculator.remove_activity(activities, 0)
+
+        assert len(new_activities) == 0
+
+    def test_remove_invalid_index(self) -> None:
+        """Test removing with invalid index raises error."""
+        activities = [ActivityLine("test", datetime(2025, 1, 1, 10, 0, 0, tzinfo=UTC), 10, 0)]
+
+        with pytest.raises(ValueError, match="Invalid index"):
+            TimeCalculator.remove_activity(activities, 5)
+
+
+class TestTimeCalculatorIntegration:
+    """Integration tests for TimeCalculator operations."""
+
+    def test_split_adjust_validate_workflow(self) -> None:
+        """Test complete workflow: split, adjust, validate."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        duration = 37 * 60 + 35  # 37 minutes 35 seconds
+        original_end = start + timedelta(seconds=duration)
+
+        # Split into 2 equal activities
+        activities = TimeCalculator.split_equal(start, duration, 2)
+
+        # Adjust first activity to 20 minutes (with original_end to adjust last activity)
+        activities = TimeCalculator.adjust_duration(activities, 0, 20, original_end)
+
+        # Create SplitActivityData and validate
+        data = SplitActivityData(
+            original_start=start,
+            original_duration_seconds=duration,
+            activities=activities
+        )
+
+        assert data.is_valid()
+
+    def test_add_remove_maintains_consistency(self) -> None:
+        """Test adding then removing maintains consistency."""
+        start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+        duration = 30 * 60
+
+        # Start with 2 activities
+        activities = TimeCalculator.split_equal(start, duration, 2)
+
+        # Add a third
+        activities = TimeCalculator.add_activity(
+            activities,
+            start + timedelta(seconds=duration),
+            equal_distribution=True,
+            original_start=start,
+            original_duration_seconds=duration
+        )
+
+        # Verify we have 3
+        assert len(activities) == 3
+
+        # Remove the middle one
+        activities = TimeCalculator.remove_activity(activities, 1)
+
+        # Verify we're back to 2
+        assert len(activities) == 2
+
+        # Validate consistency
+        data = SplitActivityData(
+            original_start=start,
+            original_duration_seconds=duration,
+            activities=activities
+        )
+        assert data.is_valid()

--- a/tests/test_split_posting.py
+++ b/tests/test_split_posting.py
@@ -1,0 +1,265 @@
+"""Integration tests for posting split events to ActivityWatch."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock
+
+import aw_core
+
+from aw_watcher_ask_away.core import AWAskAwayClient
+from aw_watcher_ask_away.split_dialog import ActivityLine
+
+
+def test_post_split_events_creates_multiple_events() -> None:
+    """Test that post_split_events creates multiple events with split metadata."""
+    # Create mock client
+    mock_client = Mock()
+    mock_client.client_hostname = "test_host"
+    mock_client.get_buckets.return_value = {
+        "aw-watcher-afk_test_host": {"type": "afkstatus"},
+        "aw-watcher-ask-away_test_host": {"type": "afktask"},
+    }
+    mock_client.get_events.return_value = []
+    mock_client.insert_event = Mock()
+
+    # Create client wrapper
+    client = AWAskAwayClient(mock_client, enable_lid_events=False)
+
+    # Create test AFK event
+    original_start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+    original_event = aw_core.Event(
+        timestamp=original_start,
+        duration=timedelta(minutes=30),
+        data={"status": "afk"},
+    )
+
+    # Create split activities
+    activities = [
+        ActivityLine("lunch", original_start, 15, 0),
+        ActivityLine("phone", original_start + timedelta(minutes=15), 15, 0),
+    ]
+
+    # Post split events
+    client.post_split_events(original_event, activities)
+
+    # Verify insert_event was called twice
+    assert mock_client.insert_event.call_count == 2
+
+    # Verify first call has correct metadata
+    first_call = mock_client.insert_event.call_args_list[0]
+    first_event = first_call[0][1]  # Second argument to insert_event
+    assert first_event.data["message"] == "lunch"
+    assert first_event.data["split"] is True
+    assert first_event.data["split_count"] == 2
+    assert first_event.data["split_index"] == 0
+    assert "split_id" in first_event.data
+
+    # Verify second call has correct metadata
+    second_call = mock_client.insert_event.call_args_list[1]
+    second_event = second_call[0][1]
+    assert second_event.data["message"] == "phone"
+    assert second_event.data["split"] is True
+    assert second_event.data["split_count"] == 2
+    assert second_event.data["split_index"] == 1
+    assert "split_id" in second_event.data
+
+    # Verify same split_id for both
+    assert first_event.data["split_id"] == second_event.data["split_id"]
+
+
+def test_post_split_events_preserves_timestamps() -> None:
+    """Test that split events preserve the correct timestamps and durations."""
+    mock_client = Mock()
+    mock_client.client_hostname = "test_host"
+    mock_client.get_buckets.return_value = {
+        "aw-watcher-afk_test_host": {"type": "afkstatus"},
+        "aw-watcher-ask-away_test_host": {"type": "afktask"},
+    }
+    mock_client.get_events.return_value = []
+    mock_client.insert_event = Mock()
+
+    client = AWAskAwayClient(mock_client, enable_lid_events=False)
+
+    original_start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+    original_event = aw_core.Event(
+        timestamp=original_start,
+        duration=timedelta(minutes=45, seconds=30),
+        data={"status": "afk"},
+    )
+
+    activities = [
+        ActivityLine("first", original_start, 10, 15),
+        ActivityLine("second", original_start + timedelta(minutes=10, seconds=15), 20, 30),
+        ActivityLine("third", original_start + timedelta(minutes=30, seconds=45), 14, 45),
+    ]
+
+    client.post_split_events(original_event, activities)
+
+    # Verify correct number of calls
+    assert mock_client.insert_event.call_count == 3
+
+    # Check timestamps and durations
+    calls = mock_client.insert_event.call_args_list
+
+    # First activity: starts at original_start, duration 10m 15s
+    first_event = calls[0][0][1]
+    assert first_event.timestamp == original_start
+    assert first_event.duration == timedelta(minutes=10, seconds=15)
+
+    # Second activity: starts 10m 15s later, duration 20m 30s
+    second_event = calls[1][0][1]
+    assert second_event.timestamp == original_start + timedelta(minutes=10, seconds=15)
+    assert second_event.duration == timedelta(minutes=20, seconds=30)
+
+    # Third activity: starts 30m 45s later, duration 14m 45s
+    third_event = calls[2][0][1]
+    assert third_event.timestamp == original_start + timedelta(minutes=30, seconds=45)
+    assert third_event.duration == timedelta(minutes=14, seconds=45)
+
+
+def test_post_split_events_marks_original_as_seen_on_success() -> None:
+    """Test that original event is marked as seen only after all splits post successfully."""
+    mock_client = Mock()
+    mock_client.client_hostname = "test_host"
+    mock_client.get_buckets.return_value = {
+        "aw-watcher-afk_test_host": {"type": "afkstatus"},
+        "aw-watcher-ask-away_test_host": {"type": "afktask"},
+    }
+    mock_client.get_events.return_value = []
+    mock_client.insert_event = Mock()  # All succeed
+
+    client = AWAskAwayClient(mock_client, enable_lid_events=False)
+
+    original_start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+    original_event = aw_core.Event(
+        timestamp=original_start,
+        duration=timedelta(minutes=20),
+        data={"status": "afk"},
+    )
+
+    activities = [
+        ActivityLine("first", original_start, 10, 0),
+        ActivityLine("second", original_start + timedelta(minutes=10), 10, 0),
+    ]
+
+    # State should not have the event initially
+    assert not client.state.has_event(original_event)
+
+    # Post split events
+    client.post_split_events(original_event, activities)
+
+    # State should now have the event marked as seen
+    assert client.state.has_event(original_event)
+
+
+def test_post_split_events_does_not_mark_seen_on_partial_failure() -> None:
+    """Test that original event is NOT marked as seen if any split event fails to post."""
+    mock_client = Mock()
+    mock_client.client_hostname = "test_host"
+    mock_client.get_buckets.return_value = {
+        "aw-watcher-afk_test_host": {"type": "afkstatus"},
+        "aw-watcher-ask-away_test_host": {"type": "afktask"},
+    }
+    mock_client.get_events.return_value = []
+
+    # Make the second insert fail
+    def insert_side_effect(bucket_id, event):
+        if mock_client.insert_event.call_count == 2:
+            raise Exception("Network error")
+
+    mock_client.insert_event = Mock(side_effect=insert_side_effect)
+
+    client = AWAskAwayClient(mock_client, enable_lid_events=False)
+
+    original_start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+    original_event = aw_core.Event(
+        timestamp=original_start,
+        duration=timedelta(minutes=20),
+        data={"status": "afk"},
+    )
+
+    activities = [
+        ActivityLine("first", original_start, 10, 0),
+        ActivityLine("second", original_start + timedelta(minutes=10), 10, 0),
+    ]
+
+    # State should not have the event initially
+    assert not client.state.has_event(original_event)
+
+    # Post split events (second one will fail)
+    client.post_split_events(original_event, activities)
+
+    # State should still NOT have the event marked as seen
+    assert not client.state.has_event(original_event)
+
+
+def test_post_split_events_split_id_based_on_timestamp() -> None:
+    """Test that split_id is consistently generated from the original event timestamp."""
+    mock_client = Mock()
+    mock_client.client_hostname = "test_host"
+    mock_client.get_buckets.return_value = {
+        "aw-watcher-afk_test_host": {"type": "afkstatus"},
+        "aw-watcher-ask-away_test_host": {"type": "afktask"},
+    }
+    mock_client.get_events.return_value = []
+    mock_client.insert_event = Mock()
+
+    client = AWAskAwayClient(mock_client, enable_lid_events=False)
+
+    # Use a specific timestamp
+    original_start = datetime(2025, 1, 15, 14, 30, 45, tzinfo=UTC)
+    original_event = aw_core.Event(
+        timestamp=original_start,
+        duration=timedelta(minutes=20),
+        data={"status": "afk"},
+    )
+
+    activities = [
+        ActivityLine("first", original_start, 10, 0),
+        ActivityLine("second", original_start + timedelta(minutes=10), 10, 0),
+    ]
+
+    client.post_split_events(original_event, activities)
+
+    # Get the split_id from the first posted event
+    first_call = mock_client.insert_event.call_args_list[0]
+    first_event = first_call[0][1]
+    split_id = first_event.data["split_id"]
+
+    # Verify split_id is the timestamp as a string
+    expected_split_id = str(original_start.timestamp())
+    assert split_id == expected_split_id
+
+
+def test_post_split_events_with_seconds() -> None:
+    """Test that split events correctly handle durations with seconds."""
+    mock_client = Mock()
+    mock_client.client_hostname = "test_host"
+    mock_client.get_buckets.return_value = {
+        "aw-watcher-afk_test_host": {"type": "afkstatus"},
+        "aw-watcher-ask-away_test_host": {"type": "afktask"},
+    }
+    mock_client.get_events.return_value = []
+    mock_client.insert_event = Mock()
+
+    client = AWAskAwayClient(mock_client, enable_lid_events=False)
+
+    original_start = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+    original_event = aw_core.Event(
+        timestamp=original_start,
+        duration=timedelta(minutes=5, seconds=37),
+        data={"status": "afk"},
+    )
+
+    activities = [
+        ActivityLine("first", original_start, 2, 45),
+        ActivityLine("second", original_start + timedelta(minutes=2, seconds=45), 2, 52),
+    ]
+
+    client.post_split_events(original_event, activities)
+
+    # Verify durations include seconds
+    first_event = mock_client.insert_event.call_args_list[0][0][1]
+    assert first_event.duration == timedelta(minutes=2, seconds=45)
+
+    second_event = mock_client.insert_event.call_args_list[1][0][1]
+    assert second_event.duration == timedelta(minutes=2, seconds=52)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,65 @@
+"""Tests for utils module."""
+
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from aw_watcher_ask_away.utils import LOCAL_TIMEZONE, format_time_local
+
+
+class TestFormatTimeLocal:
+    """Tests for the format_time_local function."""
+
+    def test_converts_utc_to_local(self) -> None:
+        """Test that UTC times are converted to local timezone."""
+        utc_time = datetime(2025, 1, 15, 12, 30, 0, tzinfo=timezone.utc)
+        result = format_time_local(utc_time)
+
+        # The result should be the local time equivalent
+        expected_local = utc_time.astimezone(LOCAL_TIMEZONE)
+        # Check that the formatted time matches the local conversion
+        assert result == expected_local.strftime("%H:%M") or \
+               result == expected_local.strftime("%I:%M %p").lstrip("0")
+
+    def test_includes_seconds_when_requested(self) -> None:
+        """Test that seconds are included when include_seconds=True."""
+        utc_time = datetime(2025, 1, 15, 12, 30, 45, tzinfo=timezone.utc)
+        result = format_time_local(utc_time, include_seconds=True)
+
+        # Should contain seconds (either HH:MM:SS or H:MM:SS AM/PM format)
+        assert "45" in result or ":45" in result
+
+    def test_no_seconds_by_default(self) -> None:
+        """Test that seconds are not included by default."""
+        utc_time = datetime(2025, 1, 15, 12, 30, 45, tzinfo=timezone.utc)
+        result = format_time_local(utc_time)
+
+        # Should not contain seconds
+        # Format is either HH:MM or H:MM AM/PM
+        parts = result.replace(" AM", "").replace(" PM", "").split(":")
+        assert len(parts) == 2  # Only hours and minutes
+
+    def test_handles_timezone_aware_datetime(self) -> None:
+        """Test that timezone-aware datetimes are handled correctly."""
+        # Create a datetime in a different timezone (UTC+5)
+        tz_plus5 = timezone(timedelta(hours=5))
+        dt = datetime(2025, 1, 15, 17, 30, 0, tzinfo=tz_plus5)
+
+        result = format_time_local(dt)
+
+        # The result should be a valid time string
+        assert result is not None
+        assert len(result) >= 4  # At minimum "H:MM"
+
+    def test_output_format_is_consistent(self) -> None:
+        """Test that output format is consistent for same locale."""
+        utc_time1 = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        utc_time2 = datetime(2025, 1, 15, 22, 0, 0, tzinfo=timezone.utc)
+
+        result1 = format_time_local(utc_time1)
+        result2 = format_time_local(utc_time2)
+
+        # Both should use same format (either both 24h or both 12h)
+        is_12h_1 = "AM" in result1 or "PM" in result1
+        is_12h_2 = "AM" in result2 or "PM" in result2
+        assert is_12h_1 == is_12h_2


### PR DESCRIPTION
When doing multiple things in an afk period, it may be nice to add multiple lables for this.  This PR adds functionality for adding more lines to an afk event.  Each line has a starting time and a duration, those may be easily edited.  Both the starting time and duration may be edited, and everything gets auto-updated to keep the consistency.

This pull request includes my other pull requests.

This PR fixes https://github.com/Jeremiah-England/aw-watcher-ask-away/issues/4

Disclaimer: most of the code was generated by AI (Claude).  Very little QA of the code itself has been done using "Natural Stupidity", but quite some testing efforts have been done.
